### PR TITLE
Update security policy to allow gtm extension

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -181,7 +181,8 @@ module.exports = {
             "'unsafe-inline'",
             "blob:",
             "https://fonts.googleapis.com",
-            "https://*.netlify.com"
+            "https://*.netlify.com",
+            "https://www.tagmanager.google.com"
           ],
           'font-src': [
             "'self'",
@@ -204,7 +205,8 @@ module.exports = {
             "https://*.netlify.com",
             "https://www.gstatic.com",
             "https://www.google-analytics.com",
-            "https://www.googletagmanager.com"
+            "https://www.googletagmanager.com",
+            "https://www.tagmanager.google.com"
           ],
           'connect-src': [
             "'self'",

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -182,7 +182,7 @@ module.exports = {
             "blob:",
             "https://fonts.googleapis.com",
             "https://*.netlify.com",
-            "https://www.tagmanager.google.com"
+            "https://tagmanager.google.com/debug/css.css"
           ],
           'font-src': [
             "'self'",

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -298,7 +298,8 @@ module.exports = {
             "'unsafe-inline'",
             "blob:",
             "https://fonts.googleapis.com",
-            "https://*.netlify.com"
+            "https://*.netlify.com",
+            "https://www.tagmanager.google.com"
           ],
           'font-src': [
             "'self'",
@@ -322,7 +323,8 @@ module.exports = {
             "https://*.netlify.com",
             "https://www.gstatic.com",
             "https://www.google-analytics.com",
-            "https://www.googletagmanager.com"
+            "https://www.googletagmanager.com",
+            "https://www.tagmanager.google.com"
           ],
           'connect-src': [
             "'self'",

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -299,7 +299,7 @@ module.exports = {
             "blob:",
             "https://fonts.googleapis.com",
             "https://*.netlify.com",
-            "https://www.tagmanager.google.com"
+            "https://tagmanager.google.com/debug/css.css"
           ],
           'font-src': [
             "'self'",


### PR DESCRIPTION
The gtm environment's debugger didn't work:
(as in not the chrome extensions, but the one from GTM itself)
![image (4)](https://user-images.githubusercontent.com/21171954/65585640-13f45400-df83-11e9-8289-641c713f5919.png)

