### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ React Frontend for giftaid submissions.
 ## Installation
 
 You will need to be a member of the Comic Relief organisation on NPM in order to install this project, as it has the
-private NPM package `@comicrelief/data-models` as a dependency.
+private NPM package `@comicrelief/data-models` as a dev dependency.
 
 ```bash
 npm login

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ React Frontend for giftaid submissions.
 
 ## Installation
 
+You will need to be a member of the Comic Relief organisation on NPM in order to install as this project has 
+`@comicrelief/data-models` as a dependency, which is a private NPM package.
+
+You will then need to log in to NPM by running the `npm login` command before doing `yarn install`.
+
 ```bash
 yarn install
 cp .env.dist .env

--- a/README.md
+++ b/README.md
@@ -3,12 +3,11 @@ React Frontend for giftaid submissions.
 
 ## Installation
 
-You will need to be a member of the Comic Relief organisation on NPM in order to install as this project has 
-`@comicrelief/data-models` as a dependency, which is a private NPM package.
-
-You will then need to log in to NPM by running the `npm login` command before doing `yarn install`.
+You will need to be a member of the Comic Relief organisation on NPM in order to install this project, as it has the
+private NPM package `@comicrelief/data-models` as a dependency.
 
 ```bash
+npm login
 yarn install
 cp .env.dist .env
 ```


### PR DESCRIPTION
Not actually sure if it _needs_ @comicrelief/data-models as a dependency, can't see it being used although it does seem to be a peer dependency of @comicrelief/test-utils 

(Don't know if that means it needs to be installed or not ... does `test-utils` bundle
 whatever it uses in its own release? ... definitely don't know enough to remove it)