### PR TITLE
ENG-2360: improve PCLU postcode validation

### DIFF
--- a/cypress/integration/submit_spec.js
+++ b/cypress/integration/submit_spec.js
@@ -82,7 +82,7 @@ describe('e2e test', () => {
     cy.get('#field-error--postcode>span').should('contain','Please enter a valid UK postcode, using a space and capital letters');
     cy.get('#field-input--postcode').clear().type('s66');
     cy.get('#field-error--postcode>span').should('contain','Please enter a valid UK postcode, using a space and capital letters');
-    cy.get('#field-input--postcode').clear().type('hp2 6lq');
+    cy.get('#field-input--postcode').clear().type('HP2 6LQ');
     cy.get('#postcode_button').click();
     cy.get('#field-select--addressSelect').should('be.visible').select('112 ST. AGNELLS LANE')
   });

--- a/cypress/integration/submit_spec.js
+++ b/cypress/integration/submit_spec.js
@@ -81,7 +81,7 @@ describe('e2e test', () => {
     cy.get('#field-input--postcode').clear().type('s66%');
     cy.get('#field-error--postcode>span').should('contain','Please enter a valid UK postcode, using a space and capital letters');
     cy.get('#field-input--postcode').clear().type('s66');
-    cy.get('#field-error--postcode>span').should('contain','Please enter a valid postcode');
+    cy.get('#field-error--postcode>span').should('contain','Please enter a valid UK postcode, using a space and capital letters');
     cy.get('#field-input--postcode').clear().type('hp2 6lq');
     cy.get('#postcode_button').click();
     cy.get('#field-select--addressSelect').should('be.visible').select('112 ST. AGNELLS LANE')

--- a/cypress/integration/submit_spec.js
+++ b/cypress/integration/submit_spec.js
@@ -79,7 +79,7 @@ describe('e2e test', () => {
     cy.get('#postcode_button').click();
     cy.get('#field-error--postcode>span').should('contain','No postcode provided');
     cy.get('#field-input--postcode').clear().type('s66%');
-    cy.get('#field-error--postcode>span').should('contain','Please enter a valid postcode');
+    cy.get('#field-error--postcode>span').should('contain','Please enter a valid UK postcode, using a space and capital letters');
     cy.get('#field-input--postcode').clear().type('s66');
     cy.get('#field-error--postcode>span').should('contain','Please enter a valid postcode');
     cy.get('#field-input--postcode').clear().type('hp2 6lq');

--- a/cypress/integration/submit_spec.js
+++ b/cypress/integration/submit_spec.js
@@ -78,12 +78,10 @@ describe('e2e test', () => {
     cy.get('#field-input--postcode').clear();
     cy.get('#postcode_button').click();
     cy.get('#field-error--postcode>span').should('contain','No postcode provided');
-    // Removed to reflect way looser postcode checks added to the lookup for CWG
-    // cy.get('#field-input--postcode').clear().type('s66%');
-    // cy.get('#field-error--postcode>span').should('contain','Please enter a valid postcode');
+    cy.get('#field-input--postcode').clear().type('s66%');
+    cy.get('#field-error--postcode>span').should('contain','Please enter a valid postcode');
     cy.get('#field-input--postcode').clear().type('s66');
-    cy.get('#postcode_button').click();
-    cy.get('#field-error--postcode>span').should('contain','Please enter a valid UK postcode to find your address');
+    cy.get('#field-error--postcode>span').should('contain','Please enter a valid postcode');
     cy.get('#field-input--postcode').clear().type('hp2 6lq');
     cy.get('#postcode_button').click();
     cy.get('#field-select--addressSelect').should('be.visible').select('112 ST. AGNELLS LANE')

--- a/cypress/integration/update_spec.js
+++ b/cypress/integration/update_spec.js
@@ -96,9 +96,9 @@ describe('e2e test typing transaction ID and choosing "yes" to claim gift aid on
     cy.get('#postcode_button').click();
     cy.get('#field-error--postcode>span').should('contain','No postcode provided');
     cy.get('#field-input--postcode').clear().type('s66%');
-    cy.get('#field-error--postcode>span').should('contain','Please enter a valid postcode');
+    cy.get('#field-error--postcode>span').should('contain','Please enter a valid UK postcode, using a space and capital letters');
     cy.get('#field-input--postcode').clear().type('s66');
-    cy.get('#field-error--postcode>span').should('contain','Please enter a valid postcode');
+    cy.get('#field-error--postcode>span').should('contain','Please enter a valid UK postcode, using a space and capital letters');
     cy.get('#field-input--postcode').clear().type('se1 7tp');
     cy.get('button[type=submit]').click();
 

--- a/cypress/integration/update_spec.js
+++ b/cypress/integration/update_spec.js
@@ -87,9 +87,9 @@ describe('e2e test typing transaction ID and choosing "yes" to claim gift aid on
 
   it('email input field validation', () => {
     cy.get('#field-input--email').clear().type('test-@%comicrelief.com');
-    cy.get('#field-error--emailaddress > span').should('contain','Please fill in a valid email address');
+    cy.get('#field-error--email > span').should('contain','Please fill in a valid email address');
     cy.get('#field-input--email').clear().type('giftaid-staging@email.sls.comicrelief.com');
-    cy.get('#field-error--emailaddress > span').should('not.exist')
+    cy.get('#field-error--email > span').should('not.exist')
   });
 
   it('postcode field validation', () => {

--- a/cypress/integration/update_spec.js
+++ b/cypress/integration/update_spec.js
@@ -95,10 +95,10 @@ describe('e2e test typing transaction ID and choosing "yes" to claim gift aid on
   it('postcode field validation', () => {
     cy.get('#postcode_button').click();
     cy.get('#field-error--postcode>span').should('contain','No postcode provided');
-    // Removed to reflect way looser postcode checks added to the lookup for CWG
-    // cy.get('#field-input--postcode').clear().type('s66%');
-    // cy.get('#field-error--postcode>span').should('contain','Please enter a valid postcode');
+    cy.get('#field-input--postcode').clear().type('s66%');
+    cy.get('#field-error--postcode>span').should('contain','Please enter a valid postcode');
     cy.get('#field-input--postcode').clear().type('s66');
+    cy.get('#field-error--postcode>span').should('contain','Please enter a valid postcode');
     cy.get('#postcode_button').click();
     cy.get('#field-error--postcode>span').should('contain','Please enter a valid UK postcode to find your address');
     cy.get('#field-input--postcode').clear().type('se1 7tp');

--- a/cypress/integration/update_spec.js
+++ b/cypress/integration/update_spec.js
@@ -104,7 +104,7 @@ describe('e2e test typing transaction ID and choosing "yes" to claim gift aid on
 
     cy.get('#field-error--addressDetails > span').should('contain','Please fill in your address');
 
-    cy.get('#field-input--postcode').clear().type('hp2 6lq');
+    cy.get('#field-input--postcode').clear().type('HP2 6LQ');
     cy.get('#postcode_button').click();
     cy.get('#field-select--addressSelect').should('be.visible').select('112 ST. AGNELLS LANE')
   });
@@ -156,7 +156,7 @@ describe('e2e test typing transaction ID and choosing "No" to claim gift aid on 
     cy.get('#field-input--firstname').clear().type(firstName);
     cy.get('#field-input--lastname').clear().type(lastName);
     cy.get('#field-input--emailaddress').clear().type('giftaid-staging@email.sls.comicrelief.com');
-    cy.get('#field-input--postcode').clear().type('hp2 6lq');
+    cy.get('#field-input--postcode').clear().type('HP2 6LQ');
     cy.get('#postcode_button').click();
     cy.get('#field-select--addressSelect').should('be.visible').select('112 ST. AGNELLS LANE');
     cy.get('input[type="radio"]').check('0').should('be.checked');
@@ -178,7 +178,7 @@ describe('Giftaid test when user comes from sms,online or call centre', () => {
     cy.get('#field-input--firstname').clear().type(firstName);
     cy.get('#field-input--lastname').clear().type(lastName);
     cy.get('#field-input--emailaddress').clear().type('giftaid-staging@email.sls.comicrelief.com');
-    cy.get('#field-input--postcode').clear().type('hp2 6lq');
+    cy.get('#field-input--postcode').clear().type('HP2 6LQ');
     cy.get('#postcode_button').click();
     cy.get('#field-select--addressSelect').should('be.visible').select('112 ST. AGNELLS LANE');
     cy.get('input[type="radio"]').check('1').should('be.checked');
@@ -197,7 +197,7 @@ describe('Giftaid test when user comes from sms,online or call centre', () => {
     cy.get('#field-input--firstname').clear().type(firstName);
     cy.get('#field-input--lastname').clear().type(lastName);
     cy.get('#field-input--emailaddress').clear().type('giftaid-staging@email.sls.comicrelief.com');
-    cy.get('#field-input--postcode').clear().type('hp2 6lq');
+    cy.get('#field-input--postcode').clear().type('HP2 6LQ');
     cy.get('#postcode_button').click();
     cy.get('#field-select--addressSelect').should('be.visible').select('112 ST. AGNELLS LANE');
     cy.get('input[type="radio"]').check('1').should('be.checked');
@@ -217,7 +217,7 @@ describe('Giftaid test when user comes from sms,online or call centre', () => {
     cy.get('#field-input--firstname').clear().type(firstName);
     cy.get('#field-input--lastname').clear().type(lastName);
     cy.get('#field-input--emailaddress').clear().type('giftaid-staging@email.sls.comicrelief.com');
-    cy.get('#field-input--postcode').clear().type('hp2 6lq');
+    cy.get('#field-input--postcode').clear().type('HP2 6LQ');
     cy.get('#postcode_button').click();
     cy.get('#field-select--addressSelect').should('be.visible').select('112 ST. AGNELLS LANE');
     cy.get('input[type="radio"]').check('1').should('be.checked');
@@ -277,7 +277,7 @@ describe('Ensure url validation if string is less than 5 characters', () => {
     cy.get('#field-input--firstname').clear().type(firstName);
     cy.get('#field-input--lastname').clear().type(lastName);
     cy.get('#field-input--emailaddress').clear().type('giftaid-staging@email.sls.comicrelief.com');
-    cy.get('#field-input--postcode').clear().type('hp2 6lq');
+    cy.get('#field-input--postcode').clear().type('HP2 6LQ');
     cy.get('#postcode_button').click();
     cy.get('#field-select--addressSelect').should('be.visible').select('112 ST. AGNELLS LANE');
     cy.get('input[type="radio"]').check(giftAidChecked).should('be.checked');

--- a/cypress/integration/update_spec.js
+++ b/cypress/integration/update_spec.js
@@ -25,7 +25,7 @@ describe('e2e test typing transaction ID and choosing "yes" to claim gift aid on
     cy.get('#field-input--transactionId');
     cy.get('#field-input--firstname');
     cy.get('#field-input--lastname');
-    cy.get('#field-input--emailaddress');
+    cy.get('#field-input--email');
     cy.get('#field-input--postcode');
     cy.get('#postcode_button');
     cy.get('a[aria-describedby=field-error--addressDetails]');
@@ -86,9 +86,9 @@ describe('e2e test typing transaction ID and choosing "yes" to claim gift aid on
   });
 
   it('email input field validation', () => {
-    cy.get('#field-input--emailaddress').clear().type('test-@%comicrelief.com');
+    cy.get('#field-input--email').clear().type('test-@%comicrelief.com');
     cy.get('#field-error--emailaddress > span').should('contain','Please fill in a valid email address');
-    cy.get('#field-input--emailaddress').clear().type('giftaid-staging@email.sls.comicrelief.com');
+    cy.get('#field-input--email').clear().type('giftaid-staging@email.sls.comicrelief.com');
     cy.get('#field-error--emailaddress > span').should('not.exist')
   });
 
@@ -138,7 +138,7 @@ describe('e2e test typing transaction ID and choosing "yes" to claim gift aid on
   });
 
   it('clear email field', () => {
-    cy.get('#field-input--emailaddress').clear()
+    cy.get('#field-input--email').clear()
   });
 
   it('verify success page', () => {
@@ -155,7 +155,7 @@ describe('e2e test typing transaction ID and choosing "No" to claim gift aid on 
     cy.get('#field-input--transactionId').clear().type('2D487A59-716B-440D-BD43-50ED301DD9BA');
     cy.get('#field-input--firstname').clear().type(firstName);
     cy.get('#field-input--lastname').clear().type(lastName);
-    cy.get('#field-input--emailaddress').clear().type('giftaid-staging@email.sls.comicrelief.com');
+    cy.get('#field-input--email').clear().type('giftaid-staging@email.sls.comicrelief.com');
     cy.get('#field-input--postcode').clear().type('HP2 6LQ');
     cy.get('#postcode_button').click();
     cy.get('#field-select--addressSelect').should('be.visible').select('112 ST. AGNELLS LANE');
@@ -177,7 +177,7 @@ describe('Giftaid test when user comes from sms,online or call centre', () => {
     cy.get('input[type="radio"]').check('sms').should('be.checked');
     cy.get('#field-input--firstname').clear().type(firstName);
     cy.get('#field-input--lastname').clear().type(lastName);
-    cy.get('#field-input--emailaddress').clear().type('giftaid-staging@email.sls.comicrelief.com');
+    cy.get('#field-input--email').clear().type('giftaid-staging@email.sls.comicrelief.com');
     cy.get('#field-input--postcode').clear().type('HP2 6LQ');
     cy.get('#postcode_button').click();
     cy.get('#field-select--addressSelect').should('be.visible').select('112 ST. AGNELLS LANE');
@@ -196,7 +196,7 @@ describe('Giftaid test when user comes from sms,online or call centre', () => {
     cy.get('input[type="radio"]').check('online').should('be.checked');
     cy.get('#field-input--firstname').clear().type(firstName);
     cy.get('#field-input--lastname').clear().type(lastName);
-    cy.get('#field-input--emailaddress').clear().type('giftaid-staging@email.sls.comicrelief.com');
+    cy.get('#field-input--email').clear().type('giftaid-staging@email.sls.comicrelief.com');
     cy.get('#field-input--postcode').clear().type('HP2 6LQ');
     cy.get('#postcode_button').click();
     cy.get('#field-select--addressSelect').should('be.visible').select('112 ST. AGNELLS LANE');
@@ -216,7 +216,7 @@ describe('Giftaid test when user comes from sms,online or call centre', () => {
     cy.get('#field-input--transactionId').clear().type('5c6a9920355f6');
     cy.get('#field-input--firstname').clear().type(firstName);
     cy.get('#field-input--lastname').clear().type(lastName);
-    cy.get('#field-input--emailaddress').clear().type('giftaid-staging@email.sls.comicrelief.com');
+    cy.get('#field-input--email').clear().type('giftaid-staging@email.sls.comicrelief.com');
     cy.get('#field-input--postcode').clear().type('HP2 6LQ');
     cy.get('#postcode_button').click();
     cy.get('#field-select--addressSelect').should('be.visible').select('112 ST. AGNELLS LANE');
@@ -262,7 +262,7 @@ describe('Ensure redirect functionality from Success page', () => {
       .get('#field-input--transactionId').should('have.value', "")
       .get('#field-input--firstname').should('have.value', "")
       .get('#field-input--lastname').should('have.value', "")
-      .get('#field-input--emailaddress').should('have.value', "")
+      .get('#field-input--email').should('have.value', "")
       .get('#field-input--postcode').should('have.value', "")
   });
 });
@@ -276,7 +276,7 @@ describe('Ensure url validation if string is less than 5 characters', () => {
     cy.get('input[type="radio"]').check('online').should('be.checked');
     cy.get('#field-input--firstname').clear().type(firstName);
     cy.get('#field-input--lastname').clear().type(lastName);
-    cy.get('#field-input--emailaddress').clear().type('giftaid-staging@email.sls.comicrelief.com');
+    cy.get('#field-input--email').clear().type('giftaid-staging@email.sls.comicrelief.com');
     cy.get('#field-input--postcode').clear().type('HP2 6LQ');
     cy.get('#postcode_button').click();
     cy.get('#field-select--addressSelect').should('be.visible').select('112 ST. AGNELLS LANE');

--- a/cypress/integration/update_spec.js
+++ b/cypress/integration/update_spec.js
@@ -99,8 +99,6 @@ describe('e2e test typing transaction ID and choosing "yes" to claim gift aid on
     cy.get('#field-error--postcode>span').should('contain','Please enter a valid postcode');
     cy.get('#field-input--postcode').clear().type('s66');
     cy.get('#field-error--postcode>span').should('contain','Please enter a valid postcode');
-    cy.get('#postcode_button').click();
-    cy.get('#field-error--postcode>span').should('contain','Please enter a valid UK postcode to find your address');
     cy.get('#field-input--postcode').clear().type('se1 7tp');
     cy.get('button[type=submit]').click();
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.11.5",
     "@comicrelief/pattern-lab": "7.58.6",
-    "@comicrelief/storybook": "1.33.2",
+    "@comicrelief/storybook": "1.33.3",
     "@snyk/protect": "^1.986.0",
     "autoprefixer": "10.0.0",
     "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.11.5",
     "@comicrelief/pattern-lab": "7.58.6",
-    "@comicrelief/storybook": "1.33.1",
+    "@comicrelief/storybook": "1.33.2",
     "@snyk/protect": "^1.986.0",
     "autoprefixer": "10.0.0",
     "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.11.5",
     "@comicrelief/pattern-lab": "7.58.6",
-    "@comicrelief/storybook": "1.31.0",
+    "@comicrelief/storybook": "1.33.0",
     "@snyk/protect": "^1.986.0",
     "autoprefixer": "10.0.0",
     "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.11.5",
     "@comicrelief/pattern-lab": "7.58.6",
-    "@comicrelief/storybook": "1.33.0",
+    "@comicrelief/storybook": "1.33.1",
     "@snyk/protect": "^1.986.0",
     "autoprefixer": "10.0.0",
     "axios": "^0.21.1",

--- a/src/pages/GiftAid/GiftAid.js
+++ b/src/pages/GiftAid/GiftAid.js
@@ -79,6 +79,27 @@ function GiftAid(props) {
     }
   }, []);
 
+  /**
+  * Crummy workaround to trigger a revalidation
+  * as the bespoke validation here has issues
+  */
+    const revalidatePostcode = () => {
+      // Store the current postcode to re-add
+      const currentPostcodeValue = document.getElementById("field-input--postcode").value;
+      const blurEvent = new Event('blur', { bubbles: true });
+
+      // Temporarily reset the postcode field and programmatically
+      // trigger a blur event to make the validation take notice
+      document.getElementById("field-input--postcode").value = '';
+      document.getElementById("field-input--postcode").dispatchEvent(blurEvent);
+
+      setTimeout(() => {
+        // Immediately re-add the value and trigger another blur event
+        document.getElementById("field-input--postcode").value = currentPostcodeValue;
+        document.getElementById("field-input--postcode").dispatchEvent(blurEvent);
+      }, 1);
+    };
+
 
   /**
    * Fetches decrypted MSISDN using token
@@ -130,14 +151,16 @@ function GiftAid(props) {
 
     if ((thisFieldsPreviousState && isUpdatedState) || marketingConsentFieldsChanged === true) {
       
-      // Update postcode regex is country select value has changed
-      if (thisFieldsName === 'country' && thisFieldsState.value !== thisFieldsPreviousState.value ){
+      // Update postcode regex is 'Country' select value has changed
+      if (thisFieldsName === 'country' && thisFieldsState.value !== thisFieldsPreviousState.value){
 
-        // Switch regex patterns if GB or not
-        setCurrentPostcodePattern(thisFieldsState.value === 'GB' ? GBPostCodePattern : OverseasPostCodePattern);
-
-        // Update counter we're using to retrigger postcode validation
-        setPostcodeRevalidate(postcodeRevalidate + 1 );
+        // Ignore the on-mount validation call
+        if (thisFieldsPreviousState.value !== undefined) {
+          // Switch regex patterns accordingly
+          setCurrentPostcodePattern(thisFieldsState.value === 'GB' ? GBPostCodePattern : OverseasPostCodePattern);
+          // Call our workaround to trigger a revalidation of the PCLU postcode field
+          revalidatePostcode();
+        }
       }
 
         // Reset url transaction Id state

--- a/src/pages/GiftAid/GiftAid.js
+++ b/src/pages/GiftAid/GiftAid.js
@@ -157,8 +157,9 @@ function GiftAid(props) {
 
         // Ignore the on-mount validation call
         if (thisFieldsPreviousState.value !== undefined) {
-          // Switch regex patterns accordingly
-          setCurrentPostcodePattern(thisFieldsState.value === 'GB' ? GBPostCodePattern : OverseasPostCodePattern);
+          // Switch regex patterns accordingly; if a non-GB value, this undefined value
+          // will cause the PCLU to fallback to its default, much looser regex
+          setCurrentPostcodePattern(thisFieldsState.value === 'GB' ? GBPostCodePattern : undefined);
           // Call our workaround to trigger a revalidation of the PCLU postcode field
           revalidatePostcode();
         }

--- a/src/pages/GiftAid/GiftAid.js
+++ b/src/pages/GiftAid/GiftAid.js
@@ -85,18 +85,19 @@ function GiftAid(props) {
   */
     const revalidatePostcode = () => {
       // Store the current postcode to re-add
-      const currentPostcodeValue = document.getElementById("field-input--postcode").value;
+      const postcodeField = document.getElementById("field-input--postcode");
+      const currentPostcodeValue = postcodeField.value;
       const blurEvent = new Event('blur', { bubbles: true });
 
       // Temporarily reset the postcode field and programmatically
       // trigger a blur event to make the validation take notice
-      document.getElementById("field-input--postcode").value = '';
-      document.getElementById("field-input--postcode").dispatchEvent(blurEvent);
+      postcodeField.value = '';
+      postcodeField.dispatchEvent(blurEvent);
 
       setTimeout(() => {
         // Immediately re-add the value and trigger another blur event
-        document.getElementById("field-input--postcode").value = currentPostcodeValue;
-        document.getElementById("field-input--postcode").dispatchEvent(blurEvent);
+        postcodeField.value = currentPostcodeValue;
+        postcodeField.dispatchEvent(blurEvent);
       }, 1);
     };
 

--- a/src/pages/GiftAid/SubmitForm/SubmitForm.js
+++ b/src/pages/GiftAid/SubmitForm/SubmitForm.js
@@ -43,7 +43,7 @@ function SubmitForm(props) {
     isSubmitting
   } = useContext(FormContext); // get states from context
 
-  const { msisdn, postcodeRevalidate } = props;
+  const { msisdn } = props;
 
   // Declare state variables
   const [inputFieldProps, setInputFieldProps] = useState([]); // initialise form inputFieldProps state
@@ -66,33 +66,6 @@ function SubmitForm(props) {
     }
   });
 
-
-  useEffect(() => {
-    revalidatePostcode(postcodeRevalidate);
-  }, [postcodeRevalidate]);
-
-  /* Crummy workaround to trigger a revalidation
-  * as the bespoke validation here is TERRIBLE */
-  const revalidatePostcode = (count) => {
-    // Ignore initial mount validation
-    if (count > 1) {
-      // Store the current postcode to re-add
-      const currentPostcodeValue = document.getElementById("field-input--postcode").value;
-      const blurEvent = new Event('blur', { bubbles: true });
-
-      // Temporarily reset the postcode field and programmatically 
-      // trigger a blur event to make the validation take notice
-      document.getElementById("field-input--postcode").value = '';
-      document.getElementById("field-input--postcode").dispatchEvent(blurEvent);
-      
-      setTimeout(() => {
-        // IMMEDIATELTY re-add the value and trigger another blur event
-        document.getElementById("field-input--postcode").value = currentPostcodeValue;
-        document.getElementById("field-input--postcode").dispatchEvent(blurEvent);
-      }, 1);
-    }
-  };
-
   /**
    * Handle set input fields
    */
@@ -113,7 +86,6 @@ function SubmitForm(props) {
     // merge input fields with default form fields
     setInputFieldProps(mergeInputFieldProps(submitFormFields, props));
   };
-
 
   return (
 

--- a/src/pages/GiftAid/SubmitForm/SubmitForm.js
+++ b/src/pages/GiftAid/SubmitForm/SubmitForm.js
@@ -131,7 +131,7 @@ function SubmitForm(props) {
         invalidErrorText="Please enter a valid UK postcode, using a space and capital letters"
         isAddressValid={
           (validation) => {
-            Object.keys(validation).map(key => setFieldValidity(validation[key], key, '(PCLU)'));
+            Object.keys(validation).map(key => setFieldValidity(validation[key], key));
           }
         }
       />

--- a/src/pages/GiftAid/SubmitForm/SubmitForm.js
+++ b/src/pages/GiftAid/SubmitForm/SubmitForm.js
@@ -101,7 +101,7 @@ function SubmitForm(props) {
         ref={refs}
         label="Home address"
         showErrorMessages={formValidityState.showErrorMessages}
-        pattern={postCodePattern}
+        postcodePattern={postCodePattern}
         isAddressValid={
           (validation) => {
             Object.keys(validation).map(key => setFieldValidity(validation[key], key));

--- a/src/pages/GiftAid/SubmitForm/SubmitForm.js
+++ b/src/pages/GiftAid/SubmitForm/SubmitForm.js
@@ -102,6 +102,7 @@ function SubmitForm(props) {
         label="Home address"
         showErrorMessages={formValidityState.showErrorMessages}
         postcodePattern={postCodePattern}
+        invalidErrorText="Please enter a valid UK postcode, using a space and capital letters"
         isAddressValid={
           (validation) => {
             Object.keys(validation).map(key => setFieldValidity(validation[key], key));

--- a/src/pages/GiftAid/SubmitForm/marketingConsentData.js
+++ b/src/pages/GiftAid/SubmitForm/marketingConsentData.js
@@ -22,7 +22,7 @@ export const marketingConsentData = {
       ],
       field: [
         {
-          id: 'emailAddress',
+          id: 'email',
           type: 'email',
           name: 'email',
           label: 'Email address',

--- a/src/pages/GiftAid/UpdateForm/UpdateForm.js
+++ b/src/pages/GiftAid/UpdateForm/UpdateForm.js
@@ -25,7 +25,7 @@ function UpdateForm(props) {
   const {
     refs,
     setFieldValidity,
-    postCodePattern,
+    currentPostcodePattern,
     justInTimeLinkText,
     formValidityState,
     fieldValidation,
@@ -60,6 +60,9 @@ function UpdateForm(props) {
     }
   }, []);
 
+
+  console.log('currentPostcodePattern', currentPostcodePattern);
+
   return (
 
     <Form className="giftaid__form update-giftaid__form">
@@ -83,7 +86,7 @@ function UpdateForm(props) {
           ref={refs}
           label="Home address"
           showErrorMessages={formValidityState.showErrorMessages}
-          postcodePattern={postCodePattern}
+          postcodePattern={currentPostcodePattern}
           invalidErrorText="Please enter a valid UK postcode, using a space and capital letters"
           isAddressValid={
             (validation) => {

--- a/src/pages/GiftAid/UpdateForm/UpdateForm.js
+++ b/src/pages/GiftAid/UpdateForm/UpdateForm.js
@@ -83,7 +83,7 @@ function UpdateForm(props) {
           ref={refs}
           label="Home address"
           showErrorMessages={formValidityState.showErrorMessages}
-          pattern={postCodePattern}
+          postcodePattern={postCodePattern}
           isAddressValid={
             (validation) => {
               Object.keys(validation).map(key => setFieldValidity(validation[key], key));

--- a/src/pages/GiftAid/UpdateForm/UpdateForm.js
+++ b/src/pages/GiftAid/UpdateForm/UpdateForm.js
@@ -60,9 +60,6 @@ function UpdateForm(props) {
     }
   }, []);
 
-
-  console.log('currentPostcodePattern', currentPostcodePattern);
-
   return (
 
     <Form className="giftaid__form update-giftaid__form">

--- a/src/pages/GiftAid/UpdateForm/UpdateForm.js
+++ b/src/pages/GiftAid/UpdateForm/UpdateForm.js
@@ -84,6 +84,7 @@ function UpdateForm(props) {
           label="Home address"
           showErrorMessages={formValidityState.showErrorMessages}
           postcodePattern={postCodePattern}
+          invalidErrorText="Please enter a valid UK postcode, using a space and capital letters"
           isAddressValid={
             (validation) => {
               Object.keys(validation).map(key => setFieldValidity(validation[key], key));

--- a/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
+++ b/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
@@ -84,8 +84,8 @@ export const updateFormFields = {
     invalidErrorText: 'This field only accepts alphanumeric characters and , . ( ) / & \' - ',
     pattern: '^[A-Za-z0-9]+[ \\- ,.()\\/&\\\'\\w]+$'
   },
-  emailAddress: {
-    id: 'emailaddress',
+  email: {
+    id: 'email',
     type: 'email',
     name: 'email',
     label: 'Email address',

--- a/src/pages/GiftAid/utils/Utils.js
+++ b/src/pages/GiftAid/utils/Utils.js
@@ -142,8 +142,9 @@ export const hiddenFields = ['field-input--address1', 'field-input--town', 'fiel
 * REGEX for postcode field, HMRC-approved to ensure no invalid GiftAid submissions can slip through
 *
 */
-export const postCodePattern = '(GIR 0AA)|((([A-Z][0-9][0-9]?)|(([A-Z][A-HJ-Y][0-9][0-9]?)|(([A-Z][0-9][A-Z])|([A-Z][A-HJ-Y][0-9]?[A-Z])))) [0-9][A-Z]{2})';
-
+// Added in optional space and made it case insenstive
+// TO-DO: check that this is re: HRMC
+export const postCodePattern = new RegExp(`(GIR 0AA)|((([A-Z][0-9][0-9]?)|(([A-Z][A-HJ-Y][0-9][0-9]?)|(([A-Z][0-9][A-Z])|([A-Z][A-HJ-Y][0-9]?[A-Z])))) {0,1}[0-9][A-Z]{2})`, 'i');
 
 /*
 * Just In Time Link Text

--- a/src/pages/GiftAid/utils/Utils.js
+++ b/src/pages/GiftAid/utils/Utils.js
@@ -139,10 +139,11 @@ const DONATION_TYPES = {
 export const hiddenFields = ['field-input--address1', 'field-input--town', 'field-wrapper--country'];
 
 /*
-* REGEX for postcode field
+* REGEX for postcode field, HMRC-approved to ensure no invalid GiftAid submissions can slip through
 *
 */
-export const postCodePattern = '[A-Za-z]{1,2}[0-9Rr][0-9A-Za-z]?( |)[0-9][ABD-HJLNP-UW-Zabd-hjlnp-uw-z]{2}';
+export const postCodePattern = '(GIR 0AA)|((([A-Z][0-9][0-9]?)|(([A-Z][A-HJ-Y][0-9][0-9]?)|(([A-Z][0-9][A-Z])|([A-Z][A-HJ-Y][0-9]?[A-Z])))) [0-9][A-Z]{2})';
+
 
 /*
 * Just In Time Link Text

--- a/src/pages/GiftAid/utils/Utils.js
+++ b/src/pages/GiftAid/utils/Utils.js
@@ -139,9 +139,13 @@ const DONATION_TYPES = {
 export const hiddenFields = ['field-input--address1', 'field-input--town', 'field-wrapper--country'];
 
 /*
-* REGEX for postcode field, HMRC-approved to ensure no invalid GiftAid submissions can slip through
+* REGEX for postcode fields:
 */
-export const postCodePattern = '(GIR 0AA)|((([A-Z][0-9][0-9]?)|(([A-Z][A-HJ-Y][0-9][0-9]?)|(([A-Z][0-9][A-Z])|([A-Z][A-HJ-Y][0-9]?[A-Z])))) [0-9][A-Z]{2})';
+// HMRC-approved to ensure no invalid GiftAid submissions can slip through
+export const GBPostCodePattern = '(GIR 0AA)|((([A-Z][0-9][0-9]?)|(([A-Z][A-HJ-Y][0-9][0-9]?)|(([A-Z][0-9][A-Z])|([A-Z][A-HJ-Y][0-9]?[A-Z])))) [0-9][A-Z]{2})';
+
+// Looser restrictions for non-GB submission
+export const OverseasPostCodePattern = '^(?!\s*$).+';
 
 /*
 * Just In Time Link Text
@@ -253,7 +257,7 @@ const getValidation = (validation) => {
 
 
 // form validity initial values
-export const initialValidity = {
+export const initialFormValidity = {
   validating: false,
   formValidity: false,
   showErrorMessages: false,

--- a/src/pages/GiftAid/utils/Utils.js
+++ b/src/pages/GiftAid/utils/Utils.js
@@ -141,11 +141,8 @@ export const hiddenFields = ['field-input--address1', 'field-input--town', 'fiel
 /*
 * REGEX for postcode fields:
 */
-// HMRC-approved to ensure no invalid GiftAid submissions can slip through
+// HMRC-approved, GB-only pattern to ensure no invalid GiftAid submissions can slip through
 export const GBPostCodePattern = '(GIR 0AA)|((([A-Z][0-9][0-9]?)|(([A-Z][A-HJ-Y][0-9][0-9]?)|(([A-Z][0-9][A-Z])|([A-Z][A-HJ-Y][0-9]?[A-Z])))) [0-9][A-Z]{2})';
-
-// Looser restrictions for non-GB submission
-export const OverseasPostCodePattern = '^(?!\s*$).+';
 
 /*
 * Just In Time Link Text

--- a/src/pages/GiftAid/utils/Utils.js
+++ b/src/pages/GiftAid/utils/Utils.js
@@ -140,9 +140,7 @@ export const hiddenFields = ['field-input--address1', 'field-input--town', 'fiel
 
 /*
 * REGEX for postcode field, HMRC-approved to ensure no invalid GiftAid submissions can slip through
-*
 */
-// Added in optional space and made it case insenstive
 export const postCodePattern = new RegExp(`(GIR 0AA)|((([A-Z][0-9][0-9]?)|(([A-Z][A-HJ-Y][0-9][0-9]?)|(([A-Z][0-9][A-Z])|([A-Z][A-HJ-Y][0-9]?[A-Z])))) [0-9][A-Z]{2})`);
 
 /*

--- a/src/pages/GiftAid/utils/Utils.js
+++ b/src/pages/GiftAid/utils/Utils.js
@@ -143,8 +143,7 @@ export const hiddenFields = ['field-input--address1', 'field-input--town', 'fiel
 *
 */
 // Added in optional space and made it case insenstive
-// TO-DO: check that this is re: HRMC
-export const postCodePattern = new RegExp(`(GIR 0AA)|((([A-Z][0-9][0-9]?)|(([A-Z][A-HJ-Y][0-9][0-9]?)|(([A-Z][0-9][A-Z])|([A-Z][A-HJ-Y][0-9]?[A-Z])))) {0,1}[0-9][A-Z]{2})`, 'i');
+export const postCodePattern = new RegExp(`(GIR 0AA)|((([A-Z][0-9][0-9]?)|(([A-Z][A-HJ-Y][0-9][0-9]?)|(([A-Z][0-9][A-Z])|([A-Z][A-HJ-Y][0-9]?[A-Z])))) [0-9][A-Z]{2})`);
 
 /*
 * Just In Time Link Text

--- a/src/pages/GiftAid/utils/Utils.js
+++ b/src/pages/GiftAid/utils/Utils.js
@@ -141,7 +141,7 @@ export const hiddenFields = ['field-input--address1', 'field-input--town', 'fiel
 /*
 * REGEX for postcode field, HMRC-approved to ensure no invalid GiftAid submissions can slip through
 */
-export const postCodePattern = new RegExp(`(GIR 0AA)|((([A-Z][0-9][0-9]?)|(([A-Z][A-HJ-Y][0-9][0-9]?)|(([A-Z][0-9][A-Z])|([A-Z][A-HJ-Y][0-9]?[A-Z])))) [0-9][A-Z]{2})`);
+export const postCodePattern = '(GIR 0AA)|((([A-Z][0-9][0-9]?)|(([A-Z][A-HJ-Y][0-9][0-9]?)|(([A-Z][0-9][A-Z])|([A-Z][A-HJ-Y][0-9]?[A-Z])))) [0-9][A-Z]{2})';
 
 /*
 * Just In Time Link Text

--- a/tests/commands/giftaid.js
+++ b/tests/commands/giftaid.js
@@ -30,7 +30,7 @@ const updateCommands = {
     return client
       .setValue('#field-input--firstname', 'test')
       .setValue('#field-input--lastname', 'user' + randomString)
-      .setValue('#field-input--emailaddress', `giftaid-staging-${randomString}@email.sls.comicrelief.com`)
+      .setValue('#field-input--email', `giftaid-staging-${randomString}@email.sls.comicrelief.com`)
       .setValue('#field-input--postcode', 'se1 7tp')
       .click('a[aria-describedby=field-error--addressDetails]')
       .pause(200)

--- a/tests/feature/submit/address.js
+++ b/tests/feature/submit/address.js
@@ -77,12 +77,12 @@ module.exports = {
     // postcode with extra numbers in first part should show error message
     client.setValue('#field-input--postcode', 'SE 134 7TP');
     client.click('#postcode_button');
-    client.expect.element('div#field-error--postcode > span').text.to.equal('Please enter a valid UK postcode to find your address');
+    client.expect.element('div#field-error--postcode > span').text.to.equal('Please enter a valid UK postcode, using a space and capital letters');
     client.clearValue('#field-input--postcode');
     // postcode with 3 numbers in second part should show error message
     client.setValue('#field-input--postcode', 'SE1 777TP');
     client.click('#postcode_button');
-    client.expect.element('div#field-error--postcode > span').text.to.equal('Please enter a valid UK postcode to find your address');
+    client.expect.element('div#field-error--postcode > span').text.to.equal('Please enter a valid UK postcode, using a space and capital letters');
     client.clearValue('#field-input--postcode');
     // postcode with 2 numbers in second part should show error message
     client.setValue('#field-input--postcode', 'SE1 77TP');

--- a/tests/feature/update/erp.js
+++ b/tests/feature/update/erp.js
@@ -60,7 +60,7 @@ const tests = {};
         client.setValue('#field-input--transactionId', transactionId);
         client.setValue('#field-input--firstname', 'test')
           .setValue('#field-input--lastname', lastName)
-          .setValue('#field-input--emailaddress', email)
+          .setValue('#field-input--email', email)
           .setValue('#field-input--postcode', 'se17tp')
           .click('a[aria-describedby=field-error--addressDetails]')
           .pause(200)

--- a/tests/feature/update/success.js
+++ b/tests/feature/update/success.js
@@ -6,7 +6,7 @@ module.exports = {
     client.url(process.env.BASE_URL + 'update/success').maximizeWindow().waitForElementVisible('body', 1000);
     client.expect.element('h1[class=giftaid-title]').text.to.equal('Giftaid it');
     client.assert.elementPresent('#field-input--transactionId');
-    client.assert.elementPresent('#field-input--emailaddress');
+    client.assert.elementPresent('#field-input--email');
     client.assert.not.elementPresent('div.success-wrapper--inner>h1');
     client.end();
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1274,10 +1274,10 @@
     susy "^2.2.12"
     underscore.string "3.3.5"
 
-"@comicrelief/storybook@1.33.2":
-  version "1.33.2"
-  resolved "https://registry.yarnpkg.com/@comicrelief/storybook/-/storybook-1.33.2.tgz#689db5f17033b686b781f431350573bf91f0e837"
-  integrity sha512-weagIT1fvQX9a1MWD9iYMd1rtRt4ncTWB2Nqt5kywCFOsqZ+iVOFKtzKkeU2qVX2HLhz6jEY2lKG3tnhUAX/Kg==
+"@comicrelief/storybook@1.33.3":
+  version "1.33.3"
+  resolved "https://registry.yarnpkg.com/@comicrelief/storybook/-/storybook-1.33.3.tgz#780ff6e9656b53098218918027f597e5ed334995"
+  integrity sha512-LbiW0wQ6+WlcKuXGQIy+z30uC1lJfDlnfp/J8r5+ku8ibV+fiJYilFNOC+gzDV2srWZhzEpTdf4/QH829TqQnQ==
   dependencies:
     "@comicrelief/pattern-lab" "*"
     "@snyk/protect" "^1.1060.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1274,10 +1274,10 @@
     susy "^2.2.12"
     underscore.string "3.3.5"
 
-"@comicrelief/storybook@1.33.1":
-  version "1.33.1"
-  resolved "https://registry.yarnpkg.com/@comicrelief/storybook/-/storybook-1.33.1.tgz#1445e48a1b199e1cd0310a94731a28072313053c"
-  integrity sha512-YR5g4/165KiStNClSQp7+M1hUT9To7e5J0DbJSUhgaDuIAyoP8ylksy3jIZD4WcfK0D7hIeENhzybf4Y2h912Q==
+"@comicrelief/storybook@1.33.2":
+  version "1.33.2"
+  resolved "https://registry.yarnpkg.com/@comicrelief/storybook/-/storybook-1.33.2.tgz#689db5f17033b686b781f431350573bf91f0e837"
+  integrity sha512-weagIT1fvQX9a1MWD9iYMd1rtRt4ncTWB2Nqt5kywCFOsqZ+iVOFKtzKkeU2qVX2HLhz6jEY2lKG3tnhUAX/Kg==
   dependencies:
     "@comicrelief/pattern-lab" "*"
     "@snyk/protect" "^1.1060.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1274,10 +1274,10 @@
     susy "^2.2.12"
     underscore.string "3.3.5"
 
-"@comicrelief/storybook@1.33.0":
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/@comicrelief/storybook/-/storybook-1.33.0.tgz#06f13350ae819f43e7cf9ac313fde671ab839222"
-  integrity sha512-rkiOtm3I09m9nOi1dYdpf8+k+J1VckXhif3Z+LY/QTtrN0fo1UguCJ67y69J8kXjTT6yArT+p1Eru7z7qIwBHA==
+"@comicrelief/storybook@1.33.1":
+  version "1.33.1"
+  resolved "https://registry.yarnpkg.com/@comicrelief/storybook/-/storybook-1.33.1.tgz#1445e48a1b199e1cd0310a94731a28072313053c"
+  integrity sha512-YR5g4/165KiStNClSQp7+M1hUT9To7e5J0DbJSUhgaDuIAyoP8ylksy3jIZD4WcfK0D7hIeENhzybf4Y2h912Q==
   dependencies:
     "@comicrelief/pattern-lab" "*"
     "@snyk/protect" "^1.1060.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1274,10 +1274,10 @@
     susy "^2.2.12"
     underscore.string "3.3.5"
 
-"@comicrelief/storybook@1.31.0":
-  version "1.31.0"
-  resolved "https://registry.yarnpkg.com/@comicrelief/storybook/-/storybook-1.31.0.tgz#76868dae623105419b17f811d41968dd5d6bd71e"
-  integrity sha512-MT5QO2GhvJkHLDYLh1tB7bsIuZRxpCIHUu/+hT8dZLmdKPBqPFyUYCycxT2mSzDVL7l256K6tqFIodNkO7bQ9Q==
+"@comicrelief/storybook@1.33.0":
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/@comicrelief/storybook/-/storybook-1.33.0.tgz#06f13350ae819f43e7cf9ac313fde671ab839222"
+  integrity sha512-rkiOtm3I09m9nOi1dYdpf8+k+J1VckXhif3Z+LY/QTtrN0fo1UguCJ67y69J8kXjTT6yArT+p1Eru7z7qIwBHA==
   dependencies:
     "@comicrelief/pattern-lab" "*"
     "@snyk/protect" "^1.1060.0"


### PR DESCRIPTION
This PR updates the postcode regex to match HMRC's requirements, and also updates the Storybook for the updated PCLU, which:
- populates the Postcode _field_ uses any returned value from a PCLU _choice_
- lets us to pass it in our new custom regex pattern
- lets us pass it a custom error message to reflect the needs of the HMRC regex

New error triggered by HMRC regex:
![Screenshot 2023-03-23 at 15 44 52](https://user-images.githubusercontent.com/4737220/227259787-5e7c3c3c-27d1-42ea-92f0-1b4c488516e8.png)

Give that this HRMC regex isn't used _universally_ (it's not appropriate for Donate, for instance), I'm not 100% sure if we need it **_this_** one in `data-models`, but we can always update it down the line, maybe adding this firm 'UK ONLY' pattern, and a more general one that'll allow just the characters we want for any worldwide postcode.