### PR TITLE
PCLU update

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.11.5",
     "@comicrelief/pattern-lab": "7.58.6",
-    "@comicrelief/storybook": "1.33.3",
+    "@comicrelief/storybook": "1.34.0",
     "@snyk/protect": "^1.986.0",
     "autoprefixer": "10.0.0",
     "axios": "^0.21.1",

--- a/src/pages/GiftAid/SubmitForm/SubmitForm.js
+++ b/src/pages/GiftAid/SubmitForm/SubmitForm.js
@@ -34,7 +34,6 @@ function SubmitForm(props) {
   const {
     refs,
     setFieldValidity,
-    currentPostcodePattern,
     justInTimeLinkText,
     formValidityState,
     fieldValidation,
@@ -99,8 +98,6 @@ function SubmitForm(props) {
         ref={refs}
         label="Home address"
         showErrorMessages={formValidityState.showErrorMessages}
-        postcodePattern={currentPostcodePattern}
-        invalidErrorText="Please enter a valid UK postcode, using a space and capital letters"
         isAddressValid={
           (validation) => {
             Object.keys(validation).map(key => setFieldValidity(validation[key], key));

--- a/src/pages/GiftAid/UpdateForm/UpdateForm.js
+++ b/src/pages/GiftAid/UpdateForm/UpdateForm.js
@@ -25,7 +25,6 @@ function UpdateForm(props) {
   const {
     refs,
     setFieldValidity,
-    currentPostcodePattern,
     justInTimeLinkText,
     formValidityState,
     fieldValidation,
@@ -83,8 +82,6 @@ function UpdateForm(props) {
           ref={refs}
           label="Home address"
           showErrorMessages={formValidityState.showErrorMessages}
-          postcodePattern={currentPostcodePattern}
-          invalidErrorText="Please enter a valid UK postcode, using a space and capital letters"
           isAddressValid={
             (validation) => {
               Object.keys(validation).map(key => setFieldValidity(validation[key], key));

--- a/src/pages/GiftAid/utils/Utils.js
+++ b/src/pages/GiftAid/utils/Utils.js
@@ -139,12 +139,6 @@ const DONATION_TYPES = {
 export const hiddenFields = ['field-input--address1', 'field-input--town', 'field-wrapper--country'];
 
 /*
-* REGEX for postcode fields:
-*/
-// HMRC-approved, GB-only pattern to ensure no invalid GiftAid submissions can slip through
-export const GBPostCodePattern = '(GIR 0AA)|((([A-Z][0-9][0-9]?)|(([A-Z][A-HJ-Y][0-9][0-9]?)|(([A-Z][0-9][A-Z])|([A-Z][A-HJ-Y][0-9]?[A-Z])))) [0-9][A-Z]{2})';
-
-/*
 * Just In Time Link Text
 *
 */

--- a/yarn.lock
+++ b/yarn.lock
@@ -1274,10 +1274,10 @@
     susy "^2.2.12"
     underscore.string "3.3.5"
 
-"@comicrelief/storybook@1.33.3":
-  version "1.33.3"
-  resolved "https://registry.yarnpkg.com/@comicrelief/storybook/-/storybook-1.33.3.tgz#780ff6e9656b53098218918027f597e5ed334995"
-  integrity sha512-LbiW0wQ6+WlcKuXGQIy+z30uC1lJfDlnfp/J8r5+ku8ibV+fiJYilFNOC+gzDV2srWZhzEpTdf4/QH829TqQnQ==
+"@comicrelief/storybook@1.34.0":
+  version "1.34.0"
+  resolved "https://registry.yarnpkg.com/@comicrelief/storybook/-/storybook-1.34.0.tgz#ac355b601280a45c076f7980806cc9f39f480373"
+  integrity sha512-/eK018inDqKdXhgkab40qwfI7VtQhtF46wjpMWtwkfNz3rJ/dA/utf2FsDZNVFegVw5sj1gJILXCgyyi7Rv26g==
   dependencies:
     "@comicrelief/pattern-lab" "*"
     "@snyk/protect" "^1.1060.0"


### PR DESCRIPTION
Removes the newly-added postcode regex patterns and re-validation, but brings them back in via the updated Storybook's PCLU.

The updated PCLU is set up to provide the same postcode patterns and error messages as we have done here in Giftaid over the last few days **_by default_**, so we shouldn't see any changes here, but the PCLU has been updated in a way that means we can easily customise other contexts (namely Donate) to work as required with minimal changes.