### PR TITLE
Add pre and post whitespace to TransactionID regex

### DIFF
--- a/playwright-staging/tests/update/formValidation.spec.js
+++ b/playwright-staging/tests/update/formValidation.spec.js
@@ -50,7 +50,7 @@ test.describe('Giftaid update form validation @sanity @nightly-sanity', () => {
     await page.close();
   });
 
-  test.only('validate transaction ID field', async ({ page }) => {
+  test('validate transaction ID field', async ({ page }) => {
 
     const commands = new Commands(page);
 
@@ -63,9 +63,14 @@ test.describe('Giftaid update form validation @sanity @nightly-sanity', () => {
     await page.waitForSelector('div#field-error--transactionId > span');
     await expect(page.locator('div#field-error--transactionId > span')).toContainText('This transaction ID doesn\'t seem to be valid, please check your donation confirmation email or letter');
 
-    // transaction ID number with special characters should shows error message
+    // transaction ID number with space at the end should not show error message
     await page.locator('input#field-input--transactionId').fill('');
     await page.locator('input#field-input--transactionId').type('a0e9840d-b724-4868-9a68-06a86e0f0150  ', {delay: 100});
+    await expect(page.locator('div#field-error--transactionId > span')).toBeHidden();
+
+    // transaction ID number with space at the beginning should not show error message
+    await page.locator('input#field-input--transactionId').fill('');
+    await page.locator('input#field-input--transactionId').type(' a0e9840d-b724-4868-9a68-06a86e0f0150', {delay: 100});
     await expect(page.locator('div#field-error--transactionId > span')).toBeHidden();
 
     // clear the transaction ID field and enter valid inputs and submit form

--- a/playwright-staging/tests/update/formValidation.spec.js
+++ b/playwright-staging/tests/update/formValidation.spec.js
@@ -50,7 +50,7 @@ test.describe('Giftaid update form validation @sanity @nightly-sanity', () => {
     await page.close();
   });
 
-  test('validate transaction ID field', async ({ page }) => {
+  test.only('validate transaction ID field', async ({ page }) => {
 
     const commands = new Commands(page);
 
@@ -62,6 +62,11 @@ test.describe('Giftaid update form validation @sanity @nightly-sanity', () => {
     await page.locator('input#field-input--transactionId').type('ea794dc3-35f8-4a87-bc94-14125fd480@$', {delay: 100});
     await page.waitForSelector('div#field-error--transactionId > span');
     await expect(page.locator('div#field-error--transactionId > span')).toContainText('This transaction ID doesn\'t seem to be valid, please check your donation confirmation email or letter');
+
+    // transaction ID number with special characters should shows error message
+    await page.locator('input#field-input--transactionId').fill('');
+    await page.locator('input#field-input--transactionId').type('a0e9840d-b724-4868-9a68-06a86e0f0150  ', {delay: 100});
+    await expect(page.locator('div#field-error--transactionId > span')).toBeHidden();
 
     // clear the transaction ID field and enter valid inputs and submit form
     await page.locator('input#field-input--transactionId').fill('');

--- a/src/pages/GiftAid/GiftAid.js
+++ b/src/pages/GiftAid/GiftAid.js
@@ -154,7 +154,8 @@ function GiftAid(props) {
       setIsSubmitting(true); // Update state that's passed down to disable button during submission
       // Rather than mess with the input field value itself (crummy UX), just sanitise the value on submission,
       // removing any leading or trailing whitespace that the new regex brings allows for (see ENG-3193) 
-      formValues.donationID = formValues.donationID.trim();
+      if (formValues.donationID) formValues.donationID = formValues.donationID.trim();
+      if (formValues.transactionId) formValues.transactionId = formValues.transactionId.trim();
 
       axios.post(pathParams.endpoint, formValues) // post form data and settings to endpoint
         .then(() => {

--- a/src/pages/GiftAid/GiftAid.js
+++ b/src/pages/GiftAid/GiftAid.js
@@ -152,6 +152,10 @@ function GiftAid(props) {
 
     if (validity) { // submit form if no errors
       setIsSubmitting(true); // Update state that's passed down to disable button during submission
+      // Rather than mess with the input field value itself (crummy UX), just sanitise the value on submission,
+      // removing any leading or trailing whitespace that the new regex brings allows for (see ENG-3193) 
+      formValues.donationID = formValues.donationID.trim();
+
       axios.post(pathParams.endpoint, formValues) // post form data and settings to endpoint
         .then(() => {
           setIsCompleted(true); // set completed state

--- a/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
+++ b/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
@@ -61,7 +61,7 @@ export const updateFormFields = {
     label: 'Transaction ID',
     required: true,
     invalidErrorText: 'This transaction ID doesn\'t seem to be valid, please check your donation confirmation email or letter',
-    pattern: '^\\s{0,1}[a-zA-Z0-9-_]{5,}\\s{0,1}$',
+    pattern: '^\\s*[a-zA-Z0-9-_]{5,}\\s*$',
     tooltip: 'This is found at the bottom of your donation confirmation email'
   },
   firstName: {

--- a/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
+++ b/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
@@ -61,7 +61,6 @@ export const updateFormFields = {
     label: 'Transaction ID',
     required: true,
     invalidErrorText: 'This transaction ID doesn\'t seem to be valid, please check your donation confirmation email or letter',
-    // eslint-disable-next-line no-useless-escape
     pattern: '^\\s{0,1}[a-zA-Z0-9-_]{5,}\\s{0,1}$',
     tooltip: 'This is found at the bottom of your donation confirmation email'
   },

--- a/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
+++ b/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
@@ -61,7 +61,8 @@ export const updateFormFields = {
     label: 'Transaction ID',
     required: true,
     invalidErrorText: 'This transaction ID doesn\'t seem to be valid, please check your donation confirmation email or letter',
-    pattern: '^[a-zA-Z0-9-_]{5,}$',
+    // eslint-disable-next-line no-useless-escape
+    pattern: '^\\s{0,1}[a-zA-Z0-9-_]{5,}\\s{0,1}$',
     tooltip: 'This is found at the bottom of your donation confirmation email'
   },
   firstName: {

--- a/src/pages/GiftAid/utils/Utils.js
+++ b/src/pages/GiftAid/utils/Utils.js
@@ -148,7 +148,7 @@ export const justInTimeLinkText = 'Why do we collect this info?';
 * REGEX for transactionId
 *
 */
-const transactionIdPattern = '^[a-zA-Z0-9-_]{5,}$';
+const transactionIdPattern = '^\\s{0,1}[a-zA-Z0-9-_]{5,}\\s{0,1}$';
 
 /**
  * Function to validate form

--- a/src/pages/GiftAid/utils/Utils.js
+++ b/src/pages/GiftAid/utils/Utils.js
@@ -148,7 +148,7 @@ export const justInTimeLinkText = 'Why do we collect this info?';
 * REGEX for transactionId
 *
 */
-const transactionIdPattern = '^\\s{0,1}[a-zA-Z0-9-_]{5,}\\s{0,1}$';
+const transactionIdPattern = '^\\s*[a-zA-Z0-9-_]{5,}\\s*$';
 
 /**
  * Function to validate form


### PR DESCRIPTION
https://comicrelief.atlassian.net/browse/ENG-3193

TransactionID field in `/update` now allows for a trailing and/or leading whitespace in order to handle any copy-paste errors, and strips this out of the submission value itself, rather than messing with the input field value directly (which would bring in its own problems).

NB: this is passed as both `transactionID` and `donationID` in the payload; I think the latter is some legacy thing maybe, or possibly used by a third party? Either way, I'm doing the same for both.

**Allowing the new spaces:** 
![Screenshot 2024-03-27 at 10 27 06](https://github.com/comicrelief/giftaid-react/assets/4737220/8a052396-d66c-4846-aa29-11dc79ab5ef7)



**Successful submission, showing the trimmed values:**
![Screenshot 2024-03-27 at 10 29 03](https://github.com/comicrelief/giftaid-react/assets/4737220/8b785d15-3124-4c39-82e7-92ba4ac29223)
