### PR TITLE
ENG-3255: 'Update' form updates - remove transactionID

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The domains for giftaid are as follows
 
 To run PR Playwright Tests locally (after running `yarn playwright install` if you haven't previously), you need to first export `REACT_APP_ENDPOINT_URL=https://giftaid-sandbox.sls.comicrelief.com/` in your terminal for the form to get submitted and then run the script `test:playwright-local:local` found in package.json; this script starts the http://localhost:3000 server in the background, config for this is found in `playwright-local/playwright-local.config.js` file and runs the tests in headless mode. 
 
-To view a test in a headed mode locally, add `--headed` flag option to `"test:playwright-local:local": "playwright test --config=./playwright-local/playwright-local.config.js --project=chromium --headed"` script found in package.json, or just use `test:playwright-local--h`.
+To view a test in a _headed_ mode locally, use the according command; `test:playwright-local--h`.
 
 To run a single test, add `only` annotation
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The domains for giftaid are as follows
 
 To run PR Playwright Tests locally (after running `yarn playwright install` if you haven't previously), you need to first export `REACT_APP_ENDPOINT_URL=https://giftaid-sandbox.sls.comicrelief.com/` in your terminal for the form to get submitted and then run the script `test:playwright-local:local` found in package.json; this script starts the http://localhost:3000 server in the background, config for this is found in `playwright-local/playwright-local.config.js` file and runs the tests in headless mode. 
 
-To view a test in a headed mode locally, add `--headed` flag option to `"test:playwright-local:local": "playwright test --config=./playwright-local/playwright-local.config.js --project=chromium --headed"` script found in package.json. 
+To view a test in a headed mode locally, add `--headed` flag option to `"test:playwright-local:local": "playwright test --config=./playwright-local/playwright-local.config.js --project=chromium --headed"` script found in package.json, or just use `test:playwright-local--h`.
 
 To run a single test, add `only` annotation
 

--- a/playwright-local/tests/update/formValidation.spec.js
+++ b/playwright-local/tests/update/formValidation.spec.js
@@ -1,8 +1,8 @@
 // @ts-check
 const { test, expect } = require('@playwright/test');
 const { Commands } = require('../utils/commands');
-const { v4: uuidv4 } = require('uuid');
-const transactionId = uuidv4();
+// const { v4: uuidv4 } = require('uuid');
+// const transactionId = uuidv4();
 
 test.describe('Giftaid update form validation', () => {
   
@@ -17,8 +17,8 @@ test.describe('Giftaid update form validation', () => {
     // submit the form
     await page.locator('button[type=submit]').click();
     
-    await expect(page.locator('div#field-error--urlTransID > span')).toContainText('This transaction ID doesn\'t seem to be valid, please check your donation confirmation email or letter');
-    await expect(page.locator('div#field-error--transactionId > span')).toContainText('Please fill in your transaction id');
+    // await expect(page.locator('div#field-error--urlTransID > span')).toContainText('This transaction ID doesn\'t seem to be valid, please check your donation confirmation email or letter');
+    // await expect(page.locator('div#field-error--transactionId > span')).toContainText('Please fill in your transaction id');
     await expect(page.locator('div#field-error--firstname > span')).toContainText('Please fill in your first name');
     await expect(page.locator('div#field-error--lastname > span')).toContainText('Please fill in your last name');
     await expect(page.locator('div#field-error--postcode > span')).toContainText('Please enter your postcode');
@@ -35,36 +35,36 @@ test.describe('Giftaid update form validation', () => {
     await page.close();
   });
   
-  test('validate transaction ID field', async ({ page }) => {
+  // test('validate transaction ID field', async ({ page }) => {
     
-    const commands = new Commands(page);
+  //   const commands = new Commands(page);
     
-    await page.locator('input#field-input--transactionId').fill(transactionId);
-    await page.locator('input#field-input--transactionId').fill('');
-    await expect(page.locator('div#field-error--transactionId > span')).toContainText('Please fill in your transaction id');
+  //   await page.locator('input#field-input--transactionId').fill(transactionId);
+  //   await page.locator('input#field-input--transactionId').fill('');
+  //   await expect(page.locator('div#field-error--transactionId > span')).toContainText('Please fill in your transaction id');
     
-    // transaction ID number with special characters should shows error message
-    await page.locator('input#field-input--transactionId').type('ea794dc3-35f8-4a87-bc94-14125fd480@$', {delay: 100});
-    await page.waitForSelector('div#field-error--transactionId > span');
-    await expect(page.locator('div#field-error--transactionId > span')).toContainText('This transaction ID doesn\'t seem to be valid, please check your donation confirmation email or letter');
+  //   // transaction ID number with special characters should shows error message
+  //   await page.locator('input#field-input--transactionId').type('ea794dc3-35f8-4a87-bc94-14125fd480@$', {delay: 100});
+  //   await page.waitForSelector('div#field-error--transactionId > span');
+  //   await expect(page.locator('div#field-error--transactionId > span')).toContainText('This transaction ID doesn\'t seem to be valid, please check your donation confirmation email or letter');
     
-    // clear the transaction ID field and enter valid inputs and submit form
-    await page.locator('input#field-input--transactionId').fill('');
+  //   // clear the transaction ID field and enter valid inputs and submit form
+  //   await page.locator('input#field-input--transactionId').fill('');
     
-    // entering valid input fields should be able to submit the form
-    await commands.populateUpdateFormFields(page);
+  //   // entering valid input fields should be able to submit the form
+  //   await commands.populateUpdateFormFields(page);
     
-    // select giftaid declaration
-    await page.locator('#giftAidClaimChoice>div:nth-child(2)>label').click();
+  //   // select giftaid declaration
+  //   await page.locator('#giftAidClaimChoice>div:nth-child(2)>label').click();
     
-    // submit the form
-    await page.locator('button[type=submit]').click();
+  //   // submit the form
+  //   await page.locator('button[type=submit]').click();
     
-    await expect(page.locator('div > h1')).toContainText('Thank you,\n' +
-      'test!');
+  //   await expect(page.locator('div > h1')).toContainText('Thank you,\n' +
+  //     'test!');
     
-    await page.close();
-  });
+  //   await page.close();
+  // });
   
   test('validate first name field on giftaid update form', async ({ page }) => {
     
@@ -234,7 +234,7 @@ test.describe('Giftaid update form validation', () => {
   test('enter valid UK postcode on giftaid update form using postcode lookup should be able to submit the form', async ({ page }) => {
     
     // fill in all input fields
-    await page.locator('input#field-input--transactionId').fill(transactionId);
+    // await page.locator('input#field-input--transactionId').fill(transactionId);
     await page.locator('#field-input--firstname').fill('test');
     await page.locator('#field-input--lastname').fill('test lastname');
     await page.locator('input#field-input--email').fill('giftaid-staging-@email.sls.comicrelief.com');

--- a/playwright-local/tests/update/formValidation.spec.js
+++ b/playwright-local/tests/update/formValidation.spec.js
@@ -14,7 +14,7 @@ test.describe('Giftaid update form validation', () => {
     
     // submit the form
     await page.locator('button[type=submit]').click();
-    
+
     await expect(page.locator('div#field-error--firstname > span')).toContainText('Please fill in your first name');
     await expect(page.locator('div#field-error--lastname > span')).toContainText('Please fill in your last name');
     await expect(page.locator('div#field-error--postcode > span')).toContainText('Please enter your postcode');
@@ -27,6 +27,9 @@ test.describe('Giftaid update form validation', () => {
     
     // giftaid declaration error message
     await expect(page.locator('div#field-error--giftAidClaimChoice > span')).toContainText('This field is required');
+
+    // DonationType error message
+    await expect(page.locator('#field-error--donationType')).toContainText('This field is required');
     
     await page.close();
   });
@@ -59,7 +62,10 @@ test.describe('Giftaid update form validation', () => {
     
     // entering valid input fields should be able to submit the form
     await commands.populateUpdateFormFields(page);
-    
+
+    // Select 'Online' donation type
+    await page.locator('#donationType>div:nth-child(3)>label').click();
+
     // select giftaid declaration
     await page.locator('#giftAidClaimChoice>div:nth-child(2)>label').click();
     
@@ -100,6 +106,9 @@ test.describe('Giftaid update form validation', () => {
     
     // entering valid input fields should be able to submit the form
     await commands.populateUpdateFormFields(page);
+
+    // Select 'Online' donation type
+    await page.locator('#donationType>div:nth-child(3)>label').click();
     
     // select giftaid declaration
     await page.locator('#giftAidClaimChoice>div:nth-child(2)>label').click();
@@ -148,10 +157,13 @@ test.describe('Giftaid update form validation', () => {
     
     // entering valid input fields should be able to submit the form
     await commands.populateUpdateFormFields(page);
-    
+
+    // Select 'Online' donation type
+    await page.locator('#donationType>div:nth-child(3)>label').click();
+
     // select giftaid declaration
     await page.locator('#giftAidClaimChoice>div:nth-child(2)>label').click();
-    
+  
     // submit the form
     await page.locator('button[type=submit]').click();
     
@@ -236,6 +248,9 @@ test.describe('Giftaid update form validation', () => {
       
       const town = await page.evaluate(() => document.querySelector('input#field-input--town').getAttribute('value'));
       console.log('Address line 1 field value is : ', town);
+
+      // Select 'Online' donation type
+      await page.locator('#donationType>div:nth-child(3)>label').click();
       
       // select giftaid declaration
       await page.locator('#giftAidClaimChoice>div:nth-child(2)>label').click();
@@ -253,6 +268,9 @@ test.describe('Giftaid update form validation', () => {
       await page.locator('#field-input--address2').type('CAMELFORD HOUSE 87-90');
       await page.locator('#field-input--address3').type('ALBERT EMBANKMENT');
       await page.locator('#field-input--town').type('LONDON');
+
+      // Select 'Online' donation type
+      await page.locator('#donationType>div:nth-child(3)>label').click();
       
       // select giftaid declaration
       await page.locator('#giftAidClaimChoice>div:nth-child(2)>label').click();

--- a/playwright-local/tests/update/formValidation.spec.js
+++ b/playwright-local/tests/update/formValidation.spec.js
@@ -1,8 +1,6 @@
 // @ts-check
 const { test, expect } = require('@playwright/test');
 const { Commands } = require('../utils/commands');
-// const { v4: uuidv4 } = require('uuid');
-// const transactionId = uuidv4();
 
 test.describe('Giftaid update form validation', () => {
   
@@ -17,8 +15,6 @@ test.describe('Giftaid update form validation', () => {
     // submit the form
     await page.locator('button[type=submit]').click();
     
-    // await expect(page.locator('div#field-error--urlTransID > span')).toContainText('This transaction ID doesn\'t seem to be valid, please check your donation confirmation email or letter');
-    // await expect(page.locator('div#field-error--transactionId > span')).toContainText('Please fill in your transaction id');
     await expect(page.locator('div#field-error--firstname > span')).toContainText('Please fill in your first name');
     await expect(page.locator('div#field-error--lastname > span')).toContainText('Please fill in your last name');
     await expect(page.locator('div#field-error--postcode > span')).toContainText('Please enter your postcode');
@@ -35,36 +31,6 @@ test.describe('Giftaid update form validation', () => {
     await page.close();
   });
   
-  // test('validate transaction ID field', async ({ page }) => {
-    
-  //   const commands = new Commands(page);
-    
-  //   await page.locator('input#field-input--transactionId').fill(transactionId);
-  //   await page.locator('input#field-input--transactionId').fill('');
-  //   await expect(page.locator('div#field-error--transactionId > span')).toContainText('Please fill in your transaction id');
-    
-  //   // transaction ID number with special characters should shows error message
-  //   await page.locator('input#field-input--transactionId').type('ea794dc3-35f8-4a87-bc94-14125fd480@$', {delay: 100});
-  //   await page.waitForSelector('div#field-error--transactionId > span');
-  //   await expect(page.locator('div#field-error--transactionId > span')).toContainText('This transaction ID doesn\'t seem to be valid, please check your donation confirmation email or letter');
-    
-  //   // clear the transaction ID field and enter valid inputs and submit form
-  //   await page.locator('input#field-input--transactionId').fill('');
-    
-  //   // entering valid input fields should be able to submit the form
-  //   await commands.populateUpdateFormFields(page);
-    
-  //   // select giftaid declaration
-  //   await page.locator('#giftAidClaimChoice>div:nth-child(2)>label').click();
-    
-  //   // submit the form
-  //   await page.locator('button[type=submit]').click();
-    
-  //   await expect(page.locator('div > h1')).toContainText('Thank you,\n' +
-  //     'test!');
-    
-  //   await page.close();
-  // });
   
   test('validate first name field on giftaid update form', async ({ page }) => {
     
@@ -234,7 +200,6 @@ test.describe('Giftaid update form validation', () => {
   test('enter valid UK postcode on giftaid update form using postcode lookup should be able to submit the form', async ({ page }) => {
     
     // fill in all input fields
-    // await page.locator('input#field-input--transactionId').fill(transactionId);
     await page.locator('#field-input--firstname').fill('test');
     await page.locator('#field-input--lastname').fill('test lastname');
     await page.locator('input#field-input--email').fill('giftaid-staging-@email.sls.comicrelief.com');

--- a/playwright-local/tests/update/formValidation.spec.js
+++ b/playwright-local/tests/update/formValidation.spec.js
@@ -175,8 +175,7 @@ test.describe('Giftaid update form validation', () => {
     await page.close();
   });
 
-  // HERE
-  test.only('Validate mobile number field', async ({ page }) => {
+  test('Validate mobile number field', async ({ page }) => {
     const commands = new Commands(page);
 
     // Test cases for various mobile number validations

--- a/playwright-local/tests/update/formValidation.spec.js
+++ b/playwright-local/tests/update/formValidation.spec.js
@@ -2,6 +2,8 @@
 const { test, expect } = require('@playwright/test');
 const { Commands } = require('../utils/commands');
 
+const email = `giftaid-staging-${Date.now().toString()}@email.sls.comicrelief.com`;
+
 test.describe('Giftaid update form validation', () => {
   
   test.beforeEach(async ({ page }) => {
@@ -192,17 +194,15 @@ test.describe('Giftaid update form validation', () => {
     }
     
     // Validate correct mobile number
-    await page.locator('#field-input--mobile').fill(''); // Ensure the field is cleared and filled with valid data
-    await commands.populateFormFields(page, { mobile: '07123456789' });
+    await page.locator('#field-input--mobile').fill(''); // Ensure the field is cleared before filling with valid data
+
+    await commands.populateUpdateFormFields(page);
 
     // Select yes for giftaid declaration to complete the form
     await page.locator('#giftAidClaimChoice>div:nth-child(2)>label').click();
 
     // Select 'Online' donation type
     await page.locator('#donationType>div:nth-child(3)>label').click();
-
-    // await page.waitForTimeout(5000);
-
 
     await page.locator('button[type=submit]').click();
     await expect(page.locator('div > h1')).toHaveText('Thank you, test!');

--- a/playwright-local/tests/update/formValidation.spec.js
+++ b/playwright-local/tests/update/formValidation.spec.js
@@ -172,6 +172,41 @@ test.describe('Giftaid update form validation', () => {
     
     await page.close();
   });
+
+  // HERE
+  test.only('Validate mobile number field', async ({ page }) => {
+    const commands = new Commands(page);
+
+    // Test cases for various mobile number validations
+    const mobileTestCases = [
+      { input: '0712345678', error: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.' },
+      { input: '0712345678900', error: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.' },
+      { input: '0712 345 6789', error: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.' },
+      { input: '0780ab5694245', error: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.' },
+    ];
+    
+    for (let testCase of mobileTestCases) {
+      await page.locator('#field-input--mobile').fill(''); // Clear the field before each test
+      await page.locator('#field-input--mobile').type(testCase.input, { delay: 100 });
+      await expect(page.locator('div#field-error--mobile > span')).toHaveText(testCase.error);
+    }
+    
+    // Validate correct mobile number
+    await page.locator('#field-input--mobile').fill(''); // Ensure the field is cleared and filled with valid data
+    await commands.populateFormFields(page, { mobile: '07123456789' });
+
+    // Select yes for giftaid declaration to complete the form
+    await page.locator('#giftAidClaimChoice>div:nth-child(2)>label').click();
+
+    // Select 'Online' donation type
+    await page.locator('#donationType>div:nth-child(3)>label').click();
+
+    // await page.waitForTimeout(5000);
+
+
+    await page.locator('button[type=submit]').click();
+    await expect(page.locator('div > h1')).toHaveText('Thank you, test!');
+  });
   
   test('postcode entered with extra spaces should show error message', async ({ page }) => {
     

--- a/playwright-local/tests/update/internationalAddressesValidation.spec.js
+++ b/playwright-local/tests/update/internationalAddressesValidation.spec.js
@@ -40,6 +40,9 @@ test.describe('International addresses validation on update form', () => {
   
     // Select yes for giftaid declaration to complete the form
     await page.locator('#giftAidClaimChoice>div:nth-child(2)>label').click();
+
+    // Select 'Online' donation type
+    await page.locator('#donationType>div:nth-child(3)>label').click();
   
     // Submitting the form with valid international details
     await page.locator('button[type=submit]').click();

--- a/playwright-local/tests/update/internationalAddressesValidation.spec.js
+++ b/playwright-local/tests/update/internationalAddressesValidation.spec.js
@@ -1,7 +1,6 @@
 // @ts-check
 const { test, expect } = require('@playwright/test');
 const { v4: uuidv4 } = require('uuid');
-// const transactionId = uuidv4();
 
 test.describe('International addresses validation on update form', () => {
   test('selecting a non-UK country and entering a non-UK postcode should submit the update form', async ({ page }) => {
@@ -11,7 +10,6 @@ test.describe('International addresses validation on update form', () => {
     await page.waitForLoadState('domcontentloaded');
 
     /// fill in all input fields
-    // await page.locator('input#field-input--transactionId').fill(transactionId);
     await page.locator('#field-input--firstname').fill('test');
     await page.locator('#field-input--lastname').fill('test lastname');
     await page.locator('input#field-input--email').fill('giftaid-staging-@email.sls.comicrelief.com');

--- a/playwright-local/tests/update/internationalAddressesValidation.spec.js
+++ b/playwright-local/tests/update/internationalAddressesValidation.spec.js
@@ -1,7 +1,7 @@
 // @ts-check
 const { test, expect } = require('@playwright/test');
 const { v4: uuidv4 } = require('uuid');
-const transactionId = uuidv4();
+// const transactionId = uuidv4();
 
 test.describe('International addresses validation on update form', () => {
   test('selecting a non-UK country and entering a non-UK postcode should submit the update form', async ({ page }) => {
@@ -11,7 +11,7 @@ test.describe('International addresses validation on update form', () => {
     await page.waitForLoadState('domcontentloaded');
 
     /// fill in all input fields
-    await page.locator('input#field-input--transactionId').fill(transactionId);
+    // await page.locator('input#field-input--transactionId').fill(transactionId);
     await page.locator('#field-input--firstname').fill('test');
     await page.locator('#field-input--lastname').fill('test lastname');
     await page.locator('input#field-input--email').fill('giftaid-staging-@email.sls.comicrelief.com');

--- a/playwright-local/tests/update/validFormSubmission.spec.js
+++ b/playwright-local/tests/update/validFormSubmission.spec.js
@@ -11,7 +11,7 @@ test('Valid Giftaid Update submission', async ({ page }) => {
   await page.waitForLoadState('domcontentloaded');
 
   // Ensure the transaction ID input is visible
-  await expect(page.locator('input#field-input--transactionId')).toBeVisible();
+  // await expect(page.locator('input#field-input--transactionId')).toBeVisible();
 
   // Populate all input fields with valid data
   await commands.populateUpdateFormFields(page);

--- a/playwright-local/tests/update/validFormSubmission.spec.js
+++ b/playwright-local/tests/update/validFormSubmission.spec.js
@@ -16,6 +16,9 @@ test('Valid Giftaid Update submission', async ({ page }) => {
   // Select 'Yes' for GiftAid declaration
   await page.locator('#giftAidClaimChoice>div:nth-child(2)>label').click();
 
+  // Select 'Online' donation type
+  await page.locator('#donationType>div:nth-child(3)>label').click();
+
   // Submit the form and validate the thank you message
   await page.locator('button[type=submit]').click();
   await expect(page.locator('div > h1')).toContainText('Thank you,\n' +

--- a/playwright-local/tests/update/validFormSubmission.spec.js
+++ b/playwright-local/tests/update/validFormSubmission.spec.js
@@ -10,9 +10,6 @@ test('Valid Giftaid Update submission', async ({ page }) => {
 
   await page.waitForLoadState('domcontentloaded');
 
-  // Ensure the transaction ID input is visible
-  // await expect(page.locator('input#field-input--transactionId')).toBeVisible();
-
   // Populate all input fields with valid data
   await commands.populateUpdateFormFields(page);
 

--- a/playwright-local/tests/utils/commands.js
+++ b/playwright-local/tests/utils/commands.js
@@ -1,11 +1,9 @@
-// const { v4: uuidv4 } = require('uuid');
 const Chance = require('chance');
 const chance = new Chance();
 
 class Commands {
   constructor(page) {
     this.page = page;
-    // this.transactionId = uuidv4();
   }
   
   /**
@@ -56,7 +54,6 @@ class Commands {
    * @param userData - Optional user data for form filling.
    */
   async populateUpdateFormFields(page, {
-    // transactionID = this.transactionId,
     firstName = 'test',
     lastName = chance.last(),
     email = `giftaid-update-staging-${chance.email()}`,
@@ -66,8 +63,6 @@ class Commands {
     address3 = 'test address 3',
     town = chance.city(),
   } = {}) {
-    // await page.locator('input#field-input--transactionId').fill(transactionID);
-    // console.log('transactionId is:', transactionID);
     await page.locator('input#field-input--firstname').fill(firstName);
     await page.locator('input#field-input--lastname').fill(lastName);
     await page.locator('input#field-input--postcode').fill(postcode);

--- a/playwright-local/tests/utils/commands.js
+++ b/playwright-local/tests/utils/commands.js
@@ -62,6 +62,7 @@ class Commands {
     address2 = chance.street(),
     address3 = 'test address 3',
     town = chance.city(),
+    mobile = chance.phone({ country: 'uk', mobile: true }).replace(/\s/g, ''), // Remove spaces from the phone number
   } = {}) {
     await page.locator('input#field-input--firstname').fill(firstName);
     await page.locator('input#field-input--lastname').fill(lastName);
@@ -72,6 +73,7 @@ class Commands {
     await page.locator('input#field-input--address2').fill(address2);
     await page.locator('input#field-input--address3').fill(address3);
     await page.locator('input#field-input--town').fill(town);
+    await page.locator('#field-input--mobile').type(mobile);
   }
 }
 

--- a/playwright-local/tests/utils/commands.js
+++ b/playwright-local/tests/utils/commands.js
@@ -1,11 +1,11 @@
-const { v4: uuidv4 } = require('uuid');
+// const { v4: uuidv4 } = require('uuid');
 const Chance = require('chance');
 const chance = new Chance();
 
 class Commands {
   constructor(page) {
     this.page = page;
-    this.transactionId = uuidv4();
+    // this.transactionId = uuidv4();
   }
   
   /**
@@ -56,7 +56,7 @@ class Commands {
    * @param userData - Optional user data for form filling.
    */
   async populateUpdateFormFields(page, {
-    transactionID = this.transactionId,
+    // transactionID = this.transactionId,
     firstName = 'test',
     lastName = chance.last(),
     email = `giftaid-update-staging-${chance.email()}`,
@@ -66,8 +66,8 @@ class Commands {
     address3 = 'test address 3',
     town = chance.city(),
   } = {}) {
-    await page.locator('input#field-input--transactionId').fill(transactionID);
-    console.log('transactionId is:', transactionID);
+    // await page.locator('input#field-input--transactionId').fill(transactionID);
+    // console.log('transactionId is:', transactionID);
     await page.locator('input#field-input--firstname').fill(firstName);
     await page.locator('input#field-input--lastname').fill(lastName);
     await page.locator('input#field-input--postcode').fill(postcode);

--- a/playwright-staging/tests/update/formValidation.spec.js
+++ b/playwright-staging/tests/update/formValidation.spec.js
@@ -8,12 +8,9 @@ const chance = new Chance();
 
 test.describe('Giftaid Update form validation @sanity @nightly-sanity', () => {
   let commands;
-  // transactionId;
   
   test.beforeEach(async ({ page }) => {
-    commands = new Commands(page);
-    // transactionId = uuidv4();  // Ensure unique transaction ID for each test
-    
+    commands = new Commands(page);    
     // Navigate to the Giftaid Update form
     await page.goto(`${process.env.BASE_URL}update`, { waitUntil: 'networkidle' });
   });
@@ -23,7 +20,6 @@ test.describe('Giftaid Update form validation @sanity @nightly-sanity', () => {
     await page.click('button[type=submit]');
     
     // Check for the error messages associated with each field
-    // await expect(page.locator('div#field-error--transactionId > span')).toHaveText('Please fill in your transaction id');
     await expect(page.locator('div#field-error--firstname > span')).toHaveText('Please fill in your first name');
     await expect(page.locator('div#field-error--lastname > span')).toHaveText('Please fill in your last name');
     await expect(page.locator('div#field-error--postcode > span')).toHaveText('Please enter your postcode');
@@ -31,35 +27,6 @@ test.describe('Giftaid Update form validation @sanity @nightly-sanity', () => {
     await expect(page.locator('div#field-error--giftAidClaimChoice > span')).toHaveText('This field is required');
     await page.close();
   });
-  
-  // test('Validate transaction ID field', async ({ page }) => {
-  //   const commands = new Commands(page);
-    
-  //   // Test cases for various transaction ID validations
-  //   // const transactionIDTestCases = [
-  //   //   { input: '', error: 'Please fill in your transaction id' },
-  //   //   { input: 'ea794dc3-35f8-4a87-bc94-14125fd480@$', error: 'This transaction ID doesn\'t seem to be valid, please check your donation confirmation email or letter' },
-  //   //   { input: ' a0e9840d-b724-4868-9a68-06a86e0f0150 ', error: null } // Expects no error for valid input with spaces around it
-  //   // ];
-    
-  //   // for (let testCase of transactionIDTestCases) {
-  //   //   await page.fill('input#field-input--transactionId', testCase.input);
-  //   //   await page.click('button[type=submit]'); // Trigger validation by attempting to submit the form
-  //   //   if (testCase.error) {
-  //   //     await expect(page.locator('div#field-error--transactionId > span')).toHaveText(testCase.error);
-  //   //   } else {
-  //   //     await expect(page.locator('div#field-error--transactionId > span')).toBeHidden();
-  //   //   }
-  //   // }
-    
-  //   // Enter a valid transaction ID and submit the form to validate successful submission
-  //   // await page.fill('input#field-input--transactionId', ''); // clear the transaction field
-  //   await commands.populateUpdateFormFields(page); // populate giftaid update form
-  //   await page.locator('#giftAidClaimChoice>div:nth-child(2)>label').click(); // select giftaid declaration
-  //   await page.click('button[type=submit]'); // submit giftaid update form
-  //   await expect(page.locator('div > h1')).toHaveText('Thank you, test!');
-  //   await page.close();
-  // });
   
   test('Validate first name field on Giftaid update form', async ({ page }) => {
     const commands = new Commands(page);
@@ -161,7 +128,6 @@ test.describe('Giftaid Update form validation @sanity @nightly-sanity', () => {
       await page.click('button[type=submit]');
     }
   
-    // await page.locator('input#field-input--transactionId').fill(transactionId);
     await page.locator('input#field-input--firstname').fill('test');
     await page.locator('input#field-input--lastname').fill(chance.last());
     await page.locator('input#field-input--email').fill(`giftaid-update-staging-${chance.email()}`);

--- a/playwright-staging/tests/update/formValidation.spec.js
+++ b/playwright-staging/tests/update/formValidation.spec.js
@@ -6,7 +6,7 @@ const { v4: uuidv4 } = require('uuid');
 const Chance = require('chance');
 const chance = new Chance();
 
-test.describe.only('Giftaid Update form validation @sanity @nightly-sanity', () => {
+test.describe('Giftaid Update form validation @sanity @nightly-sanity', () => {
   let commands;
   
   test.beforeEach(async ({ page }) => {
@@ -14,7 +14,6 @@ test.describe.only('Giftaid Update form validation @sanity @nightly-sanity', () 
     // Navigate to the Giftaid Update form
     await page.goto(`${process.env.BASE_URL}update`, { timeout: 30000 });
     await page.waitForLoadState('domcontentloaded');
-    await page.locator('.form__radio input[type="radio"][value="online"]').click();
   });
   
   test('empty input fields should show error messages', async ({ page }) => {
@@ -22,6 +21,7 @@ test.describe.only('Giftaid Update form validation @sanity @nightly-sanity', () 
     await page.click('button[type=submit]');
     
     // Check for the error messages associated with each field
+    await expect(page.locator('div#field-error--donationType > span')).toHaveText('This field is required');
     await expect(page.locator('div#field-error--firstname > span')).toHaveText('Please fill in your first name');
     await expect(page.locator('div#field-error--lastname > span')).toHaveText('Please fill in your last name');
     await expect(page.locator('div#field-error--email > span')).toHaveText('Please fill in your email address');
@@ -51,6 +51,7 @@ test.describe.only('Giftaid Update form validation @sanity @nightly-sanity', () 
     
     // Test for a valid first name
     await page.fill('#field-input--firstname', ''); // clear firstname field
+    await page.locator('.form__radio input[type="radio"][value="online"]').click();
     await commands.populateUpdateFormFields(page, { firstName: 'John' });
     await page.click('#giftAidClaimChoice>div:nth-child(2)>label'); // Select yes for declaration
     // Select 'Online' donation type
@@ -88,6 +89,7 @@ test.describe.only('Giftaid Update form validation @sanity @nightly-sanity', () 
     // Test for a valid email
     const validEmail = 'test@comicrelief.com';
     await page.fill('input#field-input--email', ''); // clear email field
+    await page.locator('.form__radio input[type="radio"][value="sms"]').click();
     await commands.populateUpdateFormFields(page, { email: validEmail });
     await page.click('#giftAidClaimChoice>div:nth-child(3)>label'); // Select no for declaration
     await page.click('button[type=submit]'); // Submit the form
@@ -115,6 +117,7 @@ test.describe.only('Giftaid Update form validation @sanity @nightly-sanity', () 
     
     // Validate correct mobile number
     await page.locator('#field-input--mobile').fill(''); // Ensure the field is cleared and filled with valid data
+    await page.locator('.form__radio input[type="radio"][value="call centre"]').click();
     await commands.populateUpdateFormFields(page, { mobile: '07123456789' });
     await page.click('#giftAidClaimChoice>div:nth-child(2)>label'); // Select yes for declaration
     await page.click('button[type=submit]'); // Submit the form

--- a/playwright-staging/tests/update/formValidation.spec.js
+++ b/playwright-staging/tests/update/formValidation.spec.js
@@ -50,6 +50,8 @@ test.describe('Giftaid Update form validation @sanity @nightly-sanity', () => {
     await page.fill('#field-input--firstname', ''); // clear firstname field
     await commands.populateUpdateFormFields(page, { firstName: 'John' });
     await page.click('#giftAidClaimChoice>div:nth-child(2)>label'); // Select yes for declaration
+    // Select 'Online' donation type
+    await page.locator('#donationType>div:nth-child(3)>label').click();
     await page.click('button[type=submit]');  // Submit the form
     
     await expect(page.locator('div > h1')).toHaveText('Thank you, John!');
@@ -133,6 +135,8 @@ test.describe('Giftaid Update form validation @sanity @nightly-sanity', () => {
     await page.locator('input#field-input--email').fill(`giftaid-update-staging-${chance.email()}`);
     await page.fill('input#field-input--postcode', 'SE1 7TP');
     await page.click('#giftAidClaimChoice>div:nth-child(2)>label'); // Select yes for declaration
+    // Select 'Online' donation type
+    await page.locator('#donationType>div:nth-child(3)>label').click();
     await page.click('button[type=submit]'); // Submit the form
     
     await expect(page.locator('div > h1')).toHaveText('Thank you,  test!');

--- a/playwright-staging/tests/update/formValidation.spec.js
+++ b/playwright-staging/tests/update/formValidation.spec.js
@@ -7,11 +7,12 @@ const Chance = require('chance');
 const chance = new Chance();
 
 test.describe('Giftaid Update form validation @sanity @nightly-sanity', () => {
-  let commands, transactionId;
+  let commands;
+  // transactionId;
   
   test.beforeEach(async ({ page }) => {
     commands = new Commands(page);
-    transactionId = uuidv4();  // Ensure unique transaction ID for each test
+    // transactionId = uuidv4();  // Ensure unique transaction ID for each test
     
     // Navigate to the Giftaid Update form
     await page.goto(`${process.env.BASE_URL}update`, { waitUntil: 'networkidle' });
@@ -22,7 +23,7 @@ test.describe('Giftaid Update form validation @sanity @nightly-sanity', () => {
     await page.click('button[type=submit]');
     
     // Check for the error messages associated with each field
-    await expect(page.locator('div#field-error--transactionId > span')).toHaveText('Please fill in your transaction id');
+    // await expect(page.locator('div#field-error--transactionId > span')).toHaveText('Please fill in your transaction id');
     await expect(page.locator('div#field-error--firstname > span')).toHaveText('Please fill in your first name');
     await expect(page.locator('div#field-error--lastname > span')).toHaveText('Please fill in your last name');
     await expect(page.locator('div#field-error--postcode > span')).toHaveText('Please enter your postcode');
@@ -31,34 +32,34 @@ test.describe('Giftaid Update form validation @sanity @nightly-sanity', () => {
     await page.close();
   });
   
-  test('Validate transaction ID field', async ({ page }) => {
-    const commands = new Commands(page);
+  // test('Validate transaction ID field', async ({ page }) => {
+  //   const commands = new Commands(page);
     
-    // Test cases for various transaction ID validations
-    const transactionIDTestCases = [
-      { input: '', error: 'Please fill in your transaction id' },
-      { input: 'ea794dc3-35f8-4a87-bc94-14125fd480@$', error: 'This transaction ID doesn\'t seem to be valid, please check your donation confirmation email or letter' },
-      { input: ' a0e9840d-b724-4868-9a68-06a86e0f0150 ', error: null } // Expects no error for valid input with spaces around it
-    ];
+  //   // Test cases for various transaction ID validations
+  //   // const transactionIDTestCases = [
+  //   //   { input: '', error: 'Please fill in your transaction id' },
+  //   //   { input: 'ea794dc3-35f8-4a87-bc94-14125fd480@$', error: 'This transaction ID doesn\'t seem to be valid, please check your donation confirmation email or letter' },
+  //   //   { input: ' a0e9840d-b724-4868-9a68-06a86e0f0150 ', error: null } // Expects no error for valid input with spaces around it
+  //   // ];
     
-    for (let testCase of transactionIDTestCases) {
-      await page.fill('input#field-input--transactionId', testCase.input);
-      await page.click('button[type=submit]'); // Trigger validation by attempting to submit the form
-      if (testCase.error) {
-        await expect(page.locator('div#field-error--transactionId > span')).toHaveText(testCase.error);
-      } else {
-        await expect(page.locator('div#field-error--transactionId > span')).toBeHidden();
-      }
-    }
+  //   // for (let testCase of transactionIDTestCases) {
+  //   //   await page.fill('input#field-input--transactionId', testCase.input);
+  //   //   await page.click('button[type=submit]'); // Trigger validation by attempting to submit the form
+  //   //   if (testCase.error) {
+  //   //     await expect(page.locator('div#field-error--transactionId > span')).toHaveText(testCase.error);
+  //   //   } else {
+  //   //     await expect(page.locator('div#field-error--transactionId > span')).toBeHidden();
+  //   //   }
+  //   // }
     
-    // Enter a valid transaction ID and submit the form to validate successful submission
-    await page.fill('input#field-input--transactionId', ''); // clear the transaction field
-    await commands.populateUpdateFormFields(page); // populate giftaid update form
-    await page.locator('#giftAidClaimChoice>div:nth-child(2)>label').click(); // select giftaid declaration
-    await page.click('button[type=submit]'); // submit giftaid update form
-    await expect(page.locator('div > h1')).toHaveText('Thank you, test!');
-    await page.close();
-  });
+  //   // Enter a valid transaction ID and submit the form to validate successful submission
+  //   // await page.fill('input#field-input--transactionId', ''); // clear the transaction field
+  //   await commands.populateUpdateFormFields(page); // populate giftaid update form
+  //   await page.locator('#giftAidClaimChoice>div:nth-child(2)>label').click(); // select giftaid declaration
+  //   await page.click('button[type=submit]'); // submit giftaid update form
+  //   await expect(page.locator('div > h1')).toHaveText('Thank you, test!');
+  //   await page.close();
+  // });
   
   test('Validate first name field on Giftaid update form', async ({ page }) => {
     const commands = new Commands(page);
@@ -160,7 +161,7 @@ test.describe('Giftaid Update form validation @sanity @nightly-sanity', () => {
       await page.click('button[type=submit]');
     }
   
-    await page.locator('input#field-input--transactionId').fill(transactionId);
+    // await page.locator('input#field-input--transactionId').fill(transactionId);
     await page.locator('input#field-input--firstname').fill('test');
     await page.locator('input#field-input--lastname').fill(chance.last());
     await page.locator('input#field-input--email').fill(`giftaid-update-staging-${chance.email()}`);

--- a/playwright-staging/tests/update/giftaidDeclarationOptions.spec.js
+++ b/playwright-staging/tests/update/giftaidDeclarationOptions.spec.js
@@ -8,9 +8,6 @@ test('Validate Giftaid declaration claim selections @sanity @nightly-sanity', as
   await page.goto(process.env.BASE_URL + 'update', { timeout: 30000 });
   await page.waitForLoadState('domcontentloaded');
   
-  // Ensure transaction ID field is visible as expected
-  // await expect(page.locator('input#field-input--transactionId')).toBeVisible();
-  
   // Populate fields and submit the form to get to the Giftaid declaration part
   await commands.populateUpdateFormFields(page);
   await page.locator('button[type=submit]').click();

--- a/playwright-staging/tests/update/giftaidDeclarationOptions.spec.js
+++ b/playwright-staging/tests/update/giftaidDeclarationOptions.spec.js
@@ -21,6 +21,11 @@ test('Validate Giftaid declaration claim selections @sanity @nightly-sanity', as
   await page.locator('#giftAidClaimChoice>div:nth-child(3)>label').click();
   expect(await page.locator('#giftAidClaimChoice>div:nth-child(3)>input').isChecked()).toBeTruthy();
   expect(await page.locator('#giftAidClaimChoice>div:nth-child(2)>input').isChecked()).toBeFalsy();
+
+  // Select 'Online' donation type
+  await page.locator('#donationType>div:nth-child(3)>label').click();
+  expect(await page.locator('#donationType>div:nth-child(3)>input').isChecked()).toBeTruthy();
+  expect(await page.locator('#donationType>div:nth-child(2)>input').isChecked()).toBeFalsy();
   
   await page.locator('button[type=submit]').click();
   await expect(page.locator('div > h1')).toHaveText('Thanks for letting us know');

--- a/playwright-staging/tests/update/giftaidDeclarationOptions.spec.js
+++ b/playwright-staging/tests/update/giftaidDeclarationOptions.spec.js
@@ -9,7 +9,7 @@ test('Validate Giftaid declaration claim selections @sanity @nightly-sanity', as
   await page.waitForLoadState('domcontentloaded');
   
   // Ensure transaction ID field is visible as expected
-  await expect(page.locator('input#field-input--transactionId')).toBeVisible();
+  // await expect(page.locator('input#field-input--transactionId')).toBeVisible();
   
   // Populate fields and submit the form to get to the Giftaid declaration part
   await commands.populateUpdateFormFields(page);

--- a/playwright-staging/tests/update/internationalAddressesValidation.spec.js
+++ b/playwright-staging/tests/update/internationalAddressesValidation.spec.js
@@ -2,7 +2,6 @@
 const { expect } = require('@playwright/test');
 const { test } = require('../../browserstack');
 const { v4: uuidv4 } = require('uuid');
-// const transactionId = uuidv4();
 
 test.describe('International addresses validation on update form @sanity @nightly-sanity', () => {
   test('selecting a non-UK country and entering a non-UK postcode should submit the update form', async ({ page }) => {

--- a/playwright-staging/tests/update/internationalAddressesValidation.spec.js
+++ b/playwright-staging/tests/update/internationalAddressesValidation.spec.js
@@ -2,7 +2,7 @@
 const { expect } = require('@playwright/test');
 const { test } = require('../../browserstack');
 const { v4: uuidv4 } = require('uuid');
-const transactionId = uuidv4();
+// const transactionId = uuidv4();
 
 test.describe('International addresses validation on update form @sanity @nightly-sanity', () => {
   test('selecting a non-UK country and entering a non-UK postcode should submit the update form', async ({ page }) => {
@@ -11,7 +11,7 @@ test.describe('International addresses validation on update form @sanity @nightl
     await page.waitForLoadState('domcontentloaded');
     
     // fill in all input fields
-    await page.locator('input#field-input--transactionId').fill(transactionId);
+    // await page.locator('input#field-input--transactionId').fill(transactionId);
     await page.locator('#field-input--firstname').fill('test');
     await page.locator('#field-input--lastname').fill('test lastname');
     await page.locator('input#field-input--email').fill('giftaid-staging-@email.sls.comicrelief.com');

--- a/playwright-staging/tests/update/internationalAddressesValidation.spec.js
+++ b/playwright-staging/tests/update/internationalAddressesValidation.spec.js
@@ -8,6 +8,7 @@ test.describe('International addresses validation on update form @sanity @nightl
     
     await page.goto(process.env.BASE_URL + 'update', { timeout: 30000 });
     await page.waitForLoadState('domcontentloaded');
+    await page.locator('.form__radio input[type="radio"][value="call centre"]').click();
     
     // fill in all input fields
     // await page.locator('input#field-input--transactionId').fill(transactionId);

--- a/playwright-staging/tests/update/updateSuccessRedirect.spec.js
+++ b/playwright-staging/tests/update/updateSuccessRedirect.spec.js
@@ -13,8 +13,8 @@ test.describe('Success page redirect @sanity @nightly-sanity', () => {
     expect(pageTitle).toContain('Giftaid it');
     
     // Verify that the transaction ID input is visible
-    const transactionIdInputVisible = await page.locator('input#field-input--transactionId').isVisible();
-    expect(transactionIdInputVisible).toBeTruthy();
+    // const transactionIdInputVisible = await page.locator('input#field-input--transactionId').isVisible();
+    // expect(transactionIdInputVisible).toBeTruthy();
     
     await page.close();
   });

--- a/playwright-staging/tests/update/updateSuccessRedirect.spec.js
+++ b/playwright-staging/tests/update/updateSuccessRedirect.spec.js
@@ -12,10 +12,6 @@ test.describe('Success page redirect @sanity @nightly-sanity', () => {
     const pageTitle = await page.locator('h1[class="giftaid-title"]').textContent();
     expect(pageTitle).toContain('Giftaid it');
     
-    // Verify that the transaction ID input is visible
-    // const transactionIdInputVisible = await page.locator('input#field-input--transactionId').isVisible();
-    // expect(transactionIdInputVisible).toBeTruthy();
-    
     await page.close();
   });
 });

--- a/playwright-staging/tests/update/validFormSubmission.spec.js
+++ b/playwright-staging/tests/update/validFormSubmission.spec.js
@@ -11,7 +11,7 @@ test('Valid giftaid update submission @sanity @nightly-sanity', async ({ page })
   await page.waitForLoadState('domcontentloaded');
   
   // Ensure the transaction ID input is visible
-  await expect(page.locator('input#field-input--transactionId')).toBeVisible();
+  // await expect(page.locator('input#field-input--transactionId')).toBeVisible();
   
   // Populate all input fields with valid data
   await commands.populateUpdateFormFields(page);

--- a/playwright-staging/tests/update/validFormSubmission.spec.js
+++ b/playwright-staging/tests/update/validFormSubmission.spec.js
@@ -10,9 +10,6 @@ test('Valid giftaid update submission @sanity @nightly-sanity', async ({ page })
   await page.goto(`${process.env.BASE_URL}update`, { timeout: 30000 });
   await page.waitForLoadState('domcontentloaded');
   
-  // Ensure the transaction ID input is visible
-  // await expect(page.locator('input#field-input--transactionId')).toBeVisible();
-  
   // Populate all input fields with valid data
   await commands.populateUpdateFormFields(page);
   

--- a/playwright-staging/tests/update/validFormSubmission.spec.js
+++ b/playwright-staging/tests/update/validFormSubmission.spec.js
@@ -15,6 +15,9 @@ test('Valid giftaid update submission @sanity @nightly-sanity', async ({ page })
   
   // Select 'Yes' for GiftAid declaration
   await page.locator('#giftAidClaimChoice>div:nth-child(2)>label').click();
+
+  // Select 'Online' donation type
+  await page.locator('#donationType>div:nth-child(3)>label').click();
   
   // Submit the form and validate the thank you message
   await page.locator('button[type=submit]').click();

--- a/playwright-staging/tests/utils/commands.js
+++ b/playwright-staging/tests/utils/commands.js
@@ -1,4 +1,3 @@
-// const { v4: uuidv4 } = require('uuid');
 const Chance = require('chance');
 const chance = new Chance();
 
@@ -55,7 +54,6 @@ class Commands {
    * @param userData - Optional user data for form filling.
    */
   async populateUpdateFormFields(page, {
-    // transactionID = this.transactionId,
     firstName = 'test',
     lastName = chance.last(),
     email = `giftaid-update-staging-${chance.email()}`,

--- a/playwright-staging/tests/utils/commands.js
+++ b/playwright-staging/tests/utils/commands.js
@@ -57,6 +57,7 @@ class Commands {
     firstName = 'test',
     lastName = chance.last(),
     email = `giftaid-update-staging-${chance.email()}`,
+    mobile = '07123456789',
     postcode = chance.postcode(),
     address1 = chance.address(),
     address2 = chance.street(),
@@ -67,6 +68,7 @@ class Commands {
     await page.locator('input#field-input--lastname').fill(lastName);
     await page.locator('input#field-input--postcode').fill(postcode);
     await page.locator('input#field-input--email').fill(email);
+    await page.locator('#field-input--mobile').fill(mobile);
     await page.locator('a[aria-describedby=field-error--addressDetails]').click();
     await page.locator('input#field-input--address1').fill(address1);
     await page.locator('input#field-input--address2').fill(address2);

--- a/playwright-staging/tests/utils/commands.js
+++ b/playwright-staging/tests/utils/commands.js
@@ -1,11 +1,11 @@
-const { v4: uuidv4 } = require('uuid');
+// const { v4: uuidv4 } = require('uuid');
 const Chance = require('chance');
 const chance = new Chance();
 
 class Commands {
   constructor(page) {
     this.page = page;
-    this.transactionId = uuidv4();
+    // this.transactionId = uuidv4();
   }
 
   /**
@@ -56,7 +56,7 @@ class Commands {
    * @param userData - Optional user data for form filling.
    */
   async populateUpdateFormFields(page, {
-    transactionID = this.transactionId,
+    // transactionID = this.transactionId,
     firstName = 'test',
     lastName = chance.last(),
     email = `giftaid-update-staging-${chance.email()}`,
@@ -66,8 +66,8 @@ class Commands {
     address3 = 'test address 3',
     town = chance.city(),
   } = {}) {
-    await page.locator('input#field-input--transactionId').fill(transactionID);
-    console.log('transactionId is:', transactionID);
+    // await page.locator('input#field-input--transactionId').fill(transactionID);
+    // console.log('transactionId is:', transactionID);
     await page.locator('input#field-input--firstname').fill(firstName);
     await page.locator('input#field-input--lastname').fill(lastName);
     await page.locator('input#field-input--postcode').fill(postcode);

--- a/playwright-staging/tests/utils/commands.js
+++ b/playwright-staging/tests/utils/commands.js
@@ -5,7 +5,6 @@ const chance = new Chance();
 class Commands {
   constructor(page) {
     this.page = page;
-    // this.transactionId = uuidv4();
   }
 
   /**
@@ -66,8 +65,6 @@ class Commands {
     address3 = 'test address 3',
     town = chance.city(),
   } = {}) {
-    // await page.locator('input#field-input--transactionId').fill(transactionID);
-    // console.log('transactionId is:', transactionID);
     await page.locator('input#field-input--firstname').fill(firstName);
     await page.locator('input#field-input--lastname').fill(lastName);
     await page.locator('input#field-input--postcode').fill(postcode);

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -128,11 +128,7 @@ function App(props) {
 							path='/update/sorry'
 							render={(props) => <Sorry {...props} />}
 						/>
-						{/* <DefaultRoute
-							exact
-							path='/update/:transaction_id'
-							component={GiftAidPage}
-						/> */}
+						
 						<DefaultRoute exact path='/update' component={GiftAidPage} />
 						<DefaultRoute exact path='/:token' component={GiftAidPage} />
 						<DefaultRoute exact path='/' component={GiftAidPage} />

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -128,11 +128,11 @@ function App(props) {
 							path='/update/sorry'
 							render={(props) => <Sorry {...props} />}
 						/>
-						<DefaultRoute
+						{/* <DefaultRoute
 							exact
 							path='/update/:transaction_id'
 							component={GiftAidPage}
-						/>
+						/> */}
 						<DefaultRoute exact path='/update' component={GiftAidPage} />
 						<DefaultRoute exact path='/:token' component={GiftAidPage} />
 						<DefaultRoute exact path='/' component={GiftAidPage} />

--- a/src/components/Buttons/DonationTypeButtons/DonationTypeButtons.js
+++ b/src/components/Buttons/DonationTypeButtons/DonationTypeButtons.js
@@ -7,33 +7,29 @@ const DonationTypeButtons = (props) => {
 
   // initialise context
   const {
-    // urlTransactionId,
     formValidityState,
     refs,
     setFieldValidity,
   } = useContext(FormContext); // get props from context
 
-  // if (urlTransactionId) {
-  //   return (
-  //     <div>
-  //       <h3 className="form--update__title form--update__title--donation text-align-centre">
-  //         How did you make the donation?
-  //       </h3>
+    return (
+      <div>
+        <h3 className="form--update__title form--update__title--donation text-align-centre">
+          How did you make the donation?
+        </h3>
 
-  //       <RadioButtons
-  //         id="donationType"
-  //         name="donationType"
-  //         label="How did you make your donation?"
-  //         required
-  //         options={props.donationTypeChoices}
-  //         showErrorMessage={formValidityState.showErrorMessages}
-  //         ref={refs}
-  //         isValid={(state, id) => { setFieldValidity(state, id); }}
-  //       />
-  //     </div>
-  //   );
-  // }
-  return null;
+        <RadioButtons
+          id="donationType"
+          name="donationType"
+          label="How did you make your donation?"
+          required
+          options={props.donationTypeChoices}
+          showErrorMessage={formValidityState.showErrorMessages}
+          ref={refs}
+          isValid={(state, id) => { setFieldValidity(state, id); }}
+        />
+      </div>
+    );
 };
 
 export default DonationTypeButtons;

--- a/src/components/Buttons/DonationTypeButtons/DonationTypeButtons.js
+++ b/src/components/Buttons/DonationTypeButtons/DonationTypeButtons.js
@@ -7,32 +7,32 @@ const DonationTypeButtons = (props) => {
 
   // initialise context
   const {
-    urlTransactionId,
+    // urlTransactionId,
     formValidityState,
     refs,
     setFieldValidity,
   } = useContext(FormContext); // get props from context
 
-  if (urlTransactionId) {
-    return (
-      <div>
-        <h3 className="form--update__title form--update__title--donation text-align-centre">
-          How did you make the donation?
-        </h3>
+  // if (urlTransactionId) {
+  //   return (
+  //     <div>
+  //       <h3 className="form--update__title form--update__title--donation text-align-centre">
+  //         How did you make the donation?
+  //       </h3>
 
-        <RadioButtons
-          id="donationType"
-          name="donationType"
-          label="How did you make your donation?"
-          required
-          options={props.donationTypeChoices}
-          showErrorMessage={formValidityState.showErrorMessages}
-          ref={refs}
-          isValid={(state, id) => { setFieldValidity(state, id); }}
-        />
-      </div>
-    );
-  }
+  //       <RadioButtons
+  //         id="donationType"
+  //         name="donationType"
+  //         label="How did you make your donation?"
+  //         required
+  //         options={props.donationTypeChoices}
+  //         showErrorMessage={formValidityState.showErrorMessages}
+  //         ref={refs}
+  //         isValid={(state, id) => { setFieldValidity(state, id); }}
+  //       />
+  //     </div>
+  //   );
+  // }
   return null;
 };
 

--- a/src/components/FormHeader/UpdateHeader/index.js
+++ b/src/components/FormHeader/UpdateHeader/index.js
@@ -5,7 +5,8 @@ import SiteService from '../../../service/Site.service';
 
 const UpdateHeader = (props) => {
 
-  const { urlTransactionId } = useContext(FormContext); // get states from context
+  // const { urlTransactionId } = useContext(FormContext); // get states from context
+  
   const site = new SiteService();
   let claimCopy = null;
   switch(site.getSite()) {
@@ -25,13 +26,13 @@ const UpdateHeader = (props) => {
       <p className="text-align-centre sub-title--copy">
         {claimCopy}
       </p>
-      {typeof urlTransactionId !== 'undefined' && urlTransactionId !== null ?
+      {/* {typeof urlTransactionId !== 'undefined' && urlTransactionId !== null ?
         <p className="text-align-centre transaction-id">
           Transaction ID: {urlTransactionId}
         </p>
         :
         ''
-      }
+      } */}
     </React.Fragment>
 
   );

--- a/src/components/FormHeader/UpdateHeader/index.js
+++ b/src/components/FormHeader/UpdateHeader/index.js
@@ -1,11 +1,8 @@
 import React, { useContext } from 'react';
 
-import FormContext from "../../../context/FormContext";
 import SiteService from '../../../service/Site.service';
 
 const UpdateHeader = (props) => {
-
-  // const { urlTransactionId } = useContext(FormContext); // get states from context
   
   const site = new SiteService();
   let claimCopy = null;
@@ -26,13 +23,6 @@ const UpdateHeader = (props) => {
       <p className="text-align-centre sub-title--copy">
         {claimCopy}
       </p>
-      {/* {typeof urlTransactionId !== 'undefined' && urlTransactionId !== null ?
-        <p className="text-align-centre transaction-id">
-          Transaction ID: {urlTransactionId}
-        </p>
-        :
-        ''
-      } */}
     </React.Fragment>
 
   );

--- a/src/pages/GiftAid/GiftAid.js
+++ b/src/pages/GiftAid/GiftAid.js
@@ -118,19 +118,17 @@ function GiftAid(props) {
 
         // Currently, on mount, each field's current 'valid' value is an empty string, rather than the boolean value it SHOULD be.
         //
-        // We do actually set the appropriate config in SubmitFormFields and UpdateFormFields, but it's not being utilised properly,
-        // for reasons I haven't uncovered yet.
+        // Long story short, if the field isn't interacted with (like our optional Mobile field here potentially), it means the whole
+        // form validation check fails due to that empty string.
         //
-        // Long story short, if the field isn't interacted with (like our optional Mobile field here potentially),  it means the whole
-        // form validation check fails because of that empty string; this basically shortcircuits the validation for this specific
-        // usecase.
+        // Additionally, there's an issue around non-required fields. We do actually set the appropriate config in SubmitFormFields
+        // and UpdateFormFields, but it's not being used at all for reasons I haven't uncovered yet, very helpfully doing nothing with the 'required' flag.
+        // 
+
+        // This short-term fix below effectively shortcircuits the validation for our non-required 'mobile' /update field when it's empty:
         if (isUpdate && thisFieldsName === 'mobile' && thisFieldsState.value === '' ) {
           fieldValidation[thisFieldsName].valid = true;
         }
-
-        // if (thisFieldsName === 'email') {
-        //   console.log('EMAIL:', fieldValidation[thisFieldsName]);
-        // }
 
         setFieldValidation({...fieldValidation});
 

--- a/src/pages/GiftAid/GiftAid.js
+++ b/src/pages/GiftAid/GiftAid.js
@@ -133,7 +133,6 @@ function GiftAid(props) {
     const formValues = getFormValues(fieldValidation, updating); // get form values
     const { validity, validationState } = validateForm(fieldValidation, formValues, formValidityState); // validate form
     setFormValidityState(validationState); // update form validation state
-    console.log('SUBNIT', validity, validationState );
 
     if (validity) { // submit form if no errors
       setIsSubmitting(true); // Update state that's passed down to disable button during submission

--- a/src/pages/GiftAid/GiftAid.js
+++ b/src/pages/GiftAid/GiftAid.js
@@ -158,7 +158,7 @@ function GiftAid(props) {
       setIsSubmitting(true); // Update state that's passed down to disable button during submission
       // Rather than mess with the input field value itself (crummy UX), just sanitise the value on submission,
       // removing any leading or trailing whitespace that the new regex brings allows for (see ENG-3193) 
-      if (formValues.donationID) formValues.donationID = formValues.donationID.trim();
+      // if (formValues.donationID) formValues.donationID = formValues.donationID.trim();
       
       // if (formValues.transactionId) formValues.transactionId = formValues.transactionId.trim();
 

--- a/src/pages/GiftAid/GiftAid.js
+++ b/src/pages/GiftAid/GiftAid.js
@@ -46,9 +46,6 @@ function GiftAid(props) {
   // initialise MSISDN state
   const [msisdn, setMSISDN] = useState(null);
 
-  // initialise URL transaction id state if available
-  // const [urlTransactionId, setUrlTransactionId] = useState(props.match.params.transaction_id);
-
   /**
    * GiftAid component mounts
    */
@@ -65,7 +62,6 @@ function GiftAid(props) {
       setFormValidityState(initialFormValidity);
       setFieldValidation({});
       setUpdating(false);
-      // setUrlTransactionId(null);
       setToken(null);
       setMSISDN(null);
     }
@@ -93,10 +89,7 @@ function GiftAid(props) {
    */
   useEffect(() => {
     // Update validation accordingly on update
-    if ((formValidityState.showErrorMessages && !formValidityState.formValidity
-      && formValidityState.validating) 
-      //|| formValidityState.urlTransactionId.valid === false 
-    ) {
+    if ((formValidityState.showErrorMessages && !formValidityState.formValidity && formValidityState.validating)) {
       // update validation state
       setFormValidityState({
         ...formValidityState,
@@ -122,16 +115,6 @@ function GiftAid(props) {
       (thisFieldsState.fieldValidation !== thisFieldsPreviousState.fieldValidation);
 
     if ((thisFieldsPreviousState && isUpdatedState) || marketingConsentFieldsChanged === true) {
-        // Reset url transaction Id state
-        // if (thisFieldsName === 'transactionId' && thisFieldsState.valid) {
-        //   setFormValidityState({
-        //     ...formValidityState,
-        //     urlTransactionId: {
-        //       ...formValidityState.urlTransactionId,
-        //       valid: true,
-        //     }
-        //   });
-        // }
         fieldValidation[thisFieldsName] = thisFieldsState;
         setFieldValidation({...fieldValidation});
 
@@ -158,10 +141,10 @@ function GiftAid(props) {
       setIsSubmitting(true); // Update state that's passed down to disable button during submission
       // Rather than mess with the input field value itself (crummy UX), just sanitise the value on submission,
       // removing any leading or trailing whitespace that the new regex brings allows for (see ENG-3193) 
+
+      // TO-DO: SHOULD THIS STILL BE THERE?
       // if (formValues.donationID) formValues.donationID = formValues.donationID.trim();
       
-      // if (formValues.transactionId) formValues.transactionId = formValues.transactionId.trim();
-
       axios.post(pathParams.endpoint, formValues) // post form data and settings to endpoint
         .then(() => {
           setIsCompleted(true); // set completed state
@@ -189,7 +172,6 @@ function GiftAid(props) {
 
   // Pass context props to child components
   const contextProps = {
-    // urlTransactionId,
     hiddenFields,
     justInTimeLinkText,
     formValidityState,
@@ -207,7 +189,6 @@ function GiftAid(props) {
       { updating ? (
         <UpdateForm
           title="Update Form"
-          // urlTransactionId={urlTransactionId}
         />
       ) : (
         <SubmitForm

--- a/src/pages/GiftAid/GiftAid.js
+++ b/src/pages/GiftAid/GiftAid.js
@@ -52,7 +52,6 @@ function GiftAid(props) {
   useEffect(() => {
     setPathParams(getPathParams(updating)); // update path states
     setToken(props.match.params.token); // update token state
-    // setUrlTransactionId(props.match.params.transaction_id); // update url transaction id state
     if (token) {
       decryptToken(token); // decrypt token to MSISDN
     }
@@ -131,11 +130,10 @@ function GiftAid(props) {
    */
   const submitForm = (e) => {
     e.preventDefault();
-    const formValues = getFormValues(fieldValidation, 
-      // urlTransactionId, 
-      updating); // get form values
+    const formValues = getFormValues(fieldValidation, updating); // get form values
     const { validity, validationState } = validateForm(fieldValidation, formValues, formValidityState); // validate form
     setFormValidityState(validationState); // update form validation state
+    console.log('SUBNIT', validity, validationState );
 
     if (validity) { // submit form if no errors
       setIsSubmitting(true); // Update state that's passed down to disable button during submission

--- a/src/pages/GiftAid/GiftAid.js
+++ b/src/pages/GiftAid/GiftAid.js
@@ -32,11 +32,11 @@ function GiftAid(props) {
   const { setIsCompleted, setSuccessState } = useContext(AppContext);
 
   // Declare states
-  const isUpdateForm = props.location.pathname.includes("update"); // initialise updating param state
-  const [updating, setUpdating] = useState(isUpdateForm); // set to true if path contains the string update
+  const isUpdate = props.location.pathname.includes("update"); // initialise updating param state
+  const [isUpdateForm, setIsUpdateForm] = useState(isUpdate); // set to true if path contains the string update
   const [pathParams, setPathParams] = useState({}); // initialise submit path param state
   const [formValidityState, setFormValidityState] = useState(initialFormValidity); // intitialise form validity states
-  const [fieldValidation, setFieldValidation] = useState(getFieldValidations(isUpdateForm)); // intitialise field validation state based on form type
+  const [fieldValidation, setFieldValidation] = useState(getFieldValidations(isUpdate)); // intitialise field validation state based on form type
   const [isSubmitting, setIsSubmitting] = useState(false);
   const inputRef = useRef(null);
 
@@ -50,7 +50,7 @@ function GiftAid(props) {
    * GiftAid component mounts
    */
   useEffect(() => {
-    setPathParams(getPathParams(updating)); // update path states
+    setPathParams(getPathParams(isUpdateForm)); // update path states
     setToken(props.match.params.token); // update token state
     if (token) {
       decryptToken(token); // decrypt token to MSISDN
@@ -60,7 +60,7 @@ function GiftAid(props) {
       // reset states
       setFormValidityState(initialFormValidity);
       setFieldValidation({});
-      setUpdating(false);
+      setIsUpdateForm(false);
       setToken(null);
       setMSISDN(null);
     }
@@ -124,9 +124,13 @@ function GiftAid(props) {
         // Long story short, if the field isn't interacted with (like our optional Mobile field here potentially),  it means the whole
         // form validation check fails because of that empty string; this basically shortcircuits the validation for this specific
         // usecase.
-        if (isUpdateForm && thisFieldsName === 'mobile' && thisFieldsState.value === '' ) {
+        if (isUpdate && thisFieldsName === 'mobile' && thisFieldsState.value === '' ) {
           fieldValidation[thisFieldsName].valid = true;
         }
+
+        // if (thisFieldsName === 'email') {
+        //   console.log('EMAIL:', fieldValidation[thisFieldsName]);
+        // }
 
         setFieldValidation({...fieldValidation});
 
@@ -143,7 +147,7 @@ function GiftAid(props) {
    */
   const submitForm = (e) => {
     e.preventDefault();
-    const formValues = getFormValues(fieldValidation, updating); // get form values
+    const formValues = getFormValues(fieldValidation); // get form values
     const { validity, validationState } = validateForm(fieldValidation, formValues, formValidityState); // validate form
     setFormValidityState(validationState); // update form validation state
 
@@ -193,7 +197,7 @@ function GiftAid(props) {
   return (
     <FormProvider value={contextProps}>
 
-      { updating ? (
+      { isUpdateForm ? (
         <UpdateForm
           title="Update Form"
         />

--- a/src/pages/GiftAid/GiftAid.js
+++ b/src/pages/GiftAid/GiftAid.js
@@ -47,7 +47,7 @@ function GiftAid(props) {
   const [msisdn, setMSISDN] = useState(null);
 
   // initialise URL transaction id state if available
-  const [urlTransactionId, setUrlTransactionId] = useState(props.match.params.transaction_id);
+  // const [urlTransactionId, setUrlTransactionId] = useState(props.match.params.transaction_id);
 
   /**
    * GiftAid component mounts
@@ -55,7 +55,7 @@ function GiftAid(props) {
   useEffect(() => {
     setPathParams(getPathParams(updating)); // update path states
     setToken(props.match.params.token); // update token state
-    setUrlTransactionId(props.match.params.transaction_id); // update url transaction id state
+    // setUrlTransactionId(props.match.params.transaction_id); // update url transaction id state
     if (token) {
       decryptToken(token); // decrypt token to MSISDN
     }
@@ -65,7 +65,7 @@ function GiftAid(props) {
       setFormValidityState(initialFormValidity);
       setFieldValidation({});
       setUpdating(false);
-      setUrlTransactionId(null);
+      // setUrlTransactionId(null);
       setToken(null);
       setMSISDN(null);
     }
@@ -94,7 +94,9 @@ function GiftAid(props) {
   useEffect(() => {
     // Update validation accordingly on update
     if ((formValidityState.showErrorMessages && !formValidityState.formValidity
-      && formValidityState.validating) || formValidityState.urlTransactionId.valid === false ) {
+      && formValidityState.validating) 
+      //|| formValidityState.urlTransactionId.valid === false 
+    ) {
       // update validation state
       setFormValidityState({
         ...formValidityState,
@@ -121,15 +123,15 @@ function GiftAid(props) {
 
     if ((thisFieldsPreviousState && isUpdatedState) || marketingConsentFieldsChanged === true) {
         // Reset url transaction Id state
-        if (thisFieldsName === 'transactionId' && thisFieldsState.valid) {
-          setFormValidityState({
-            ...formValidityState,
-            urlTransactionId: {
-              ...formValidityState.urlTransactionId,
-              valid: true,
-            }
-          });
-        }
+        // if (thisFieldsName === 'transactionId' && thisFieldsState.valid) {
+        //   setFormValidityState({
+        //     ...formValidityState,
+        //     urlTransactionId: {
+        //       ...formValidityState.urlTransactionId,
+        //       valid: true,
+        //     }
+        //   });
+        // }
         fieldValidation[thisFieldsName] = thisFieldsState;
         setFieldValidation({...fieldValidation});
 
@@ -146,7 +148,9 @@ function GiftAid(props) {
    */
   const submitForm = (e) => {
     e.preventDefault();
-    const formValues = getFormValues(fieldValidation, urlTransactionId, updating); // get form values
+    const formValues = getFormValues(fieldValidation, 
+      // urlTransactionId, 
+      updating); // get form values
     const { validity, validationState } = validateForm(fieldValidation, formValues, formValidityState); // validate form
     setFormValidityState(validationState); // update form validation state
 
@@ -155,7 +159,8 @@ function GiftAid(props) {
       // Rather than mess with the input field value itself (crummy UX), just sanitise the value on submission,
       // removing any leading or trailing whitespace that the new regex brings allows for (see ENG-3193) 
       if (formValues.donationID) formValues.donationID = formValues.donationID.trim();
-      if (formValues.transactionId) formValues.transactionId = formValues.transactionId.trim();
+      
+      // if (formValues.transactionId) formValues.transactionId = formValues.transactionId.trim();
 
       axios.post(pathParams.endpoint, formValues) // post form data and settings to endpoint
         .then(() => {
@@ -184,7 +189,7 @@ function GiftAid(props) {
 
   // Pass context props to child components
   const contextProps = {
-    urlTransactionId,
+    // urlTransactionId,
     hiddenFields,
     justInTimeLinkText,
     formValidityState,
@@ -202,7 +207,7 @@ function GiftAid(props) {
       { updating ? (
         <UpdateForm
           title="Update Form"
-          urlTransactionId={urlTransactionId}
+          // urlTransactionId={urlTransactionId}
         />
       ) : (
         <SubmitForm

--- a/src/pages/GiftAid/GiftAid.js
+++ b/src/pages/GiftAid/GiftAid.js
@@ -138,9 +138,6 @@ function GiftAid(props) {
       setIsSubmitting(true); // Update state that's passed down to disable button during submission
       // Rather than mess with the input field value itself (crummy UX), just sanitise the value on submission,
       // removing any leading or trailing whitespace that the new regex brings allows for (see ENG-3193) 
-
-      // TO-DO: SHOULD THIS STILL BE THERE?
-      // if (formValues.donationID) formValues.donationID = formValues.donationID.trim();
       
       axios.post(pathParams.endpoint, formValues) // post form data and settings to endpoint
         .then(() => {

--- a/src/pages/GiftAid/GiftAid.js
+++ b/src/pages/GiftAid/GiftAid.js
@@ -32,11 +32,11 @@ function GiftAid(props) {
   const { setIsCompleted, setSuccessState } = useContext(AppContext);
 
   // Declare states
-  const update = props.location.pathname.includes("update"); // initialise updating param state
-  const [updating, setUpdating] = useState(update); // set to true if path contains the string update
+  const isUpdateForm = props.location.pathname.includes("update"); // initialise updating param state
+  const [updating, setUpdating] = useState(isUpdateForm); // set to true if path contains the string update
   const [pathParams, setPathParams] = useState({}); // initialise submit path param state
   const [formValidityState, setFormValidityState] = useState(initialFormValidity); // intitialise form validity states
-  const [fieldValidation, setFieldValidation] = useState(getFieldValidations(update)); // intitialise field validation state based on form type
+  const [fieldValidation, setFieldValidation] = useState(getFieldValidations(isUpdateForm)); // intitialise field validation state based on form type
   const [isSubmitting, setIsSubmitting] = useState(false);
   const inputRef = useRef(null);
 
@@ -115,6 +115,19 @@ function GiftAid(props) {
 
     if ((thisFieldsPreviousState && isUpdatedState) || marketingConsentFieldsChanged === true) {
         fieldValidation[thisFieldsName] = thisFieldsState;
+
+        // Currently, on mount, each field's current 'valid' value is an empty string, rather than the boolean value it SHOULD be.
+        //
+        // We do actually set the appropriate config in SubmitFormFields and UpdateFormFields, but it's not being utilised properly,
+        // for reasons I haven't uncovered yet.
+        //
+        // Long story short, if the field isn't interacted with (like our optional Mobile field here potentially),  it means the whole
+        // form validation check fails because of that empty string; this basically shortcircuits the validation for this specific
+        // usecase.
+        if (isUpdateForm && thisFieldsName === 'mobile' && thisFieldsState.value === '' ) {
+          fieldValidation[thisFieldsName].valid = true;
+        }
+
         setFieldValidation({...fieldValidation});
 
         return {

--- a/src/pages/GiftAid/GiftAid.js
+++ b/src/pages/GiftAid/GiftAid.js
@@ -121,11 +121,10 @@ function GiftAid(props) {
         // Long story short, if the field isn't interacted with (like our optional Mobile field here potentially), it means the whole
         // form validation check fails due to that empty string.
         //
-        // Additionally, there's an issue around non-required fields. We do actually set the appropriate config in SubmitFormFields
-        // and UpdateFormFields, but it's not being used at all for reasons I haven't uncovered yet, very helpfully doing nothing with the 'required' flag.
+        // Additionally, there's an issue around non-required fields. We do actually set the appropriate config in SubmitFormFields and
+        // UpdateFormFields, but it's not being used at all for reasons I haven't uncovered yet, very helpfully doing nothing with the 'required' flag.
         // 
-
-        // This short-term fix below effectively shortcircuits the validation for our non-required 'mobile' /update field when it's empty:
+        // This short-term fix below effectively shortcircuits the validation for our non-required 'mobile' UpdateForm field when it's empty:
         if (isUpdate && thisFieldsName === 'mobile' && thisFieldsState.value === '' ) {
           fieldValidation[thisFieldsName].valid = true;
         }

--- a/src/pages/GiftAid/UpdateForm/UpdateForm.js
+++ b/src/pages/GiftAid/UpdateForm/UpdateForm.js
@@ -40,7 +40,9 @@ function UpdateForm(props) {
   useEffect(() => {
     setFieldValidation(fieldValidation);
     // Reset states on component unmount
-    delete fieldValidation.donationType;
+    
+    // ADDING THIS EVERYWHERE TO /UPDATE NOW SO DON'T DELETE IT
+    // delete fieldValidation.donationType;
     return () => {
       setInputFieldProps([]);
     }
@@ -54,9 +56,7 @@ function UpdateForm(props) {
 
       <div className="form-fields--wrapper">
 
-        {/* TO-DO: ARE WE KEEPING THIS IN? */}
-
-        {/* <DonationTypeButtons donationTypeChoices={donationTypeChoices} /> */}
+        <DonationTypeButtons donationTypeChoices={donationTypeChoices} />
 
         <h3 className="form--update__title form--update__title--giftaid text-align-centre">
           Who is changing their declaration?

--- a/src/pages/GiftAid/UpdateForm/UpdateForm.js
+++ b/src/pages/GiftAid/UpdateForm/UpdateForm.js
@@ -9,8 +9,6 @@ import DonationTypeButtons from '../../../components/Buttons/DonationTypeButtons
 import GiftAidClaimChoiceButtons from '../../../components/Buttons/GiftAidClaimChoiceButtons/GiftAidClaimChoiceButtons';
 import InputFields from '../../../components/InputFields/InputFields';
 import JustInTime from '../../../components/JustInTime/index';
-// import UrlTransactionIdError from './UrlTransactionIdError';
-
 
 // fields data
 import { updateFormFields, donationTypeChoices, giftAidButtonChoices } from './UpdateFormFields';
@@ -57,7 +55,7 @@ function UpdateForm(props) {
 
         {/* TO-DO: ARE WE KEEPING THIS IN? */}
 
-        <DonationTypeButtons donationTypeChoices={donationTypeChoices} />
+        {/* <DonationTypeButtons donationTypeChoices={donationTypeChoices} /> */}
 
         <h3 className="form--update__title form--update__title--giftaid text-align-centre">
           Who is changing their declaration?

--- a/src/pages/GiftAid/UpdateForm/UpdateForm.js
+++ b/src/pages/GiftAid/UpdateForm/UpdateForm.js
@@ -40,6 +40,7 @@ function UpdateForm(props) {
   useEffect(() => {
     setFieldValidation(fieldValidation);
     // Reset states on component unmount
+    delete fieldValidation.donationType;
     return () => {
       setInputFieldProps([]);
     }

--- a/src/pages/GiftAid/UpdateForm/UpdateForm.js
+++ b/src/pages/GiftAid/UpdateForm/UpdateForm.js
@@ -9,7 +9,7 @@ import DonationTypeButtons from '../../../components/Buttons/DonationTypeButtons
 import GiftAidClaimChoiceButtons from '../../../components/Buttons/GiftAidClaimChoiceButtons/GiftAidClaimChoiceButtons';
 import InputFields from '../../../components/InputFields/InputFields';
 import JustInTime from '../../../components/JustInTime/index';
-import UrlTransactionIdError from './UrlTransactionIdError';
+// import UrlTransactionIdError from './UrlTransactionIdError';
 
 
 // fields data
@@ -33,7 +33,7 @@ function UpdateForm(props) {
   } = useContext(FormContext); // get props from context
 
 
-  const { urlTransactionId } = props;
+  // const { urlTransactionId } = props;
 
   // Declare state variables
   const [inputFieldProps, setInputFieldProps] = useState(updateFormFields); // initialise form inputFieldProps state
@@ -44,14 +44,14 @@ function UpdateForm(props) {
   useEffect(() => {
     // Delete if url trans Id if present
     // on component mount or update
-    if (urlTransactionId !== undefined) {
-      // Delete transactionId form field
-      delete inputFieldProps.transactionId;
-      delete fieldValidation.transactionId;
-    } else {
+    // if (urlTransactionId !== undefined) {
+    //   // Delete transactionId form field
+    //   delete inputFieldProps.transactionId;
+    //   delete fieldValidation.transactionId;
+    // } else {
       // Else, delete the donation type radiobuttons
       delete fieldValidation.donationType;
-    }
+    // }
     setFieldValidation(fieldValidation);
     // Reset states on component unmount
     return () => {
@@ -65,7 +65,7 @@ function UpdateForm(props) {
 
       <FormHeader page="update" />
 
-      <UrlTransactionIdError />
+      {/* <UrlTransactionIdError /> */}
 
       <div className="form-fields--wrapper">
 

--- a/src/pages/GiftAid/UpdateForm/UpdateForm.js
+++ b/src/pages/GiftAid/UpdateForm/UpdateForm.js
@@ -33,8 +33,6 @@ function UpdateForm(props) {
   } = useContext(FormContext); // get props from context
 
 
-  // const { urlTransactionId } = props;
-
   // Declare state variables
   const [inputFieldProps, setInputFieldProps] = useState(updateFormFields); // initialise form inputFieldProps state
 
@@ -42,16 +40,6 @@ function UpdateForm(props) {
    * Component mounts and updates
    */
   useEffect(() => {
-    // Delete if url trans Id if present
-    // on component mount or update
-    // if (urlTransactionId !== undefined) {
-    //   // Delete transactionId form field
-    //   delete inputFieldProps.transactionId;
-    //   delete fieldValidation.transactionId;
-    // } else {
-      // Else, delete the donation type radiobuttons
-      delete fieldValidation.donationType;
-    // }
     setFieldValidation(fieldValidation);
     // Reset states on component unmount
     return () => {
@@ -65,9 +53,9 @@ function UpdateForm(props) {
 
       <FormHeader page="update" />
 
-      {/* <UrlTransactionIdError /> */}
-
       <div className="form-fields--wrapper">
+
+        {/* TO-DO: ARE WE KEEPING THIS IN? */}
 
         <DonationTypeButtons donationTypeChoices={donationTypeChoices} />
 

--- a/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
+++ b/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
@@ -54,16 +54,16 @@ export const giftAidButtonChoices = [
 */
 export const updateFormFields = {
 
-  transactionId: {
-    id: 'transactionId',
-    type: 'text',
-    name: 'transactionId',
-    label: 'Transaction ID',
-    required: true,
-    invalidErrorText: 'This transaction ID doesn\'t seem to be valid, please check your donation confirmation email or letter',
-    pattern: '^\\s*[a-zA-Z0-9-_]{5,}\\s*$',
-    tooltip: 'This is found at the bottom of your donation confirmation email'
-  },
+  // transactionId: {
+  //   id: 'transactionId',
+  //   type: 'text',
+  //   name: 'transactionId',
+  //   label: 'Transaction ID',
+  //   required: true,
+  //   invalidErrorText: 'This transaction ID doesn\'t seem to be valid, please check your donation confirmation email or letter',
+  //   pattern: '^\\s*[a-zA-Z0-9-_]{5,}\\s*$',
+  //   tooltip: 'This is found at the bottom of your donation confirmation email'
+  // },
   firstName: {
     id: 'firstname',
     type: 'text',

--- a/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
+++ b/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
@@ -83,7 +83,12 @@ export const updateFormFields = {
     id: 'mobile',
     type: 'tel',
     name: 'mobile',
+    placeholder: 'In the format 07123456789',
     label: 'Mobile number',
     required: false,
+    pattern: '^07[0-9]{9}$',
+    helpText: 'Enter the one associated with your donation',
+    emptyFieldErrorText: 'Please fill in your mobile number',
+    invalidErrorText: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.'
   }
 };

--- a/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
+++ b/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
@@ -86,9 +86,10 @@ export const updateFormFields = {
     placeholder: 'In the format 07123456789',
     label: 'Mobile number',
     required: false,
-    pattern: '^07[0-9]{9}$',
+    pattern: '^07[0-9]{9}$', // TO-DO: check that this is appropriate or not
     helpText: 'Enter the one associated with your donation',
     emptyFieldErrorText: 'Please fill in your mobile number',
-    invalidErrorText: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.'
+    invalidErrorText: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.',
+    additionalText: 'Please note: if you donated via SMS, we DO require your number here to match this submission.',
   }
 };

--- a/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
+++ b/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
@@ -90,6 +90,6 @@ export const updateFormFields = {
     helpText: 'Enter the one associated with your donation',
     emptyFieldErrorText: 'Please fill in your mobile number',
     invalidErrorText: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.',
-    additionalText: 'Please note: if you donated via SMS, we DO require your number here to match this submission.',
+    additionalText: 'Please note: if you donated via SMS, we DO require your number here, in order to match it to this submission.',
   }
 };

--- a/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
+++ b/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
@@ -76,8 +76,8 @@ export const updateFormFields = {
     id: 'email',
     type: 'email',
     name: 'email',
-    label: 'Email address',
     required: true,
+    label: 'Email address'
   },
   mobile: {
     id: 'mobile',

--- a/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
+++ b/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
@@ -86,7 +86,7 @@ export const updateFormFields = {
     placeholder: 'In the format 07123456789',
     label: 'Mobile number',
     required: false,
-    pattern: '^07[0-9]{9}$', // TO-DO: check that this is appropriate or not
+    pattern: '^07[0-9]{9}$', // Matches the validation in the main 'submit' form
     helpText: 'Enter the one associated with your donation',
     emptyFieldErrorText: 'Please fill in your mobile number',
     invalidErrorText: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.',

--- a/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
+++ b/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
@@ -77,6 +77,13 @@ export const updateFormFields = {
     type: 'email',
     name: 'email',
     label: 'Email address',
+    required: true,
+  },
+  mobile: {
+    id: 'mobile',
+    type: 'tel',
+    name: 'mobile',
+    label: 'Mobile number',
     required: false,
   }
 };

--- a/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
+++ b/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
@@ -53,17 +53,7 @@ export const giftAidButtonChoices = [
 * Default Update Form Fields
 */
 export const updateFormFields = {
-
-  // transactionId: {
-  //   id: 'transactionId',
-  //   type: 'text',
-  //   name: 'transactionId',
-  //   label: 'Transaction ID',
-  //   required: true,
-  //   invalidErrorText: 'This transaction ID doesn\'t seem to be valid, please check your donation confirmation email or letter',
-  //   pattern: '^\\s*[a-zA-Z0-9-_]{5,}\\s*$',
-  //   tooltip: 'This is found at the bottom of your donation confirmation email'
-  // },
+  
   firstName: {
     id: 'firstname',
     type: 'text',

--- a/src/pages/GiftAid/utils/Utils.js
+++ b/src/pages/GiftAid/utils/Utils.js
@@ -89,6 +89,7 @@ export const getFormValues = (validation, update = false) => {
     fieldValues.donationID = null;
 
   // Create donation type field for Update Form
+  // TO-DO: SCOPE THIS PROPERLY
   fieldValues.donationType = typeof validation.donationType !== 'undefined'
   && validation.donationType
     ? validation.donationType.value : DONATION_TYPES.ONLINE;

--- a/src/pages/GiftAid/utils/Utils.js
+++ b/src/pages/GiftAid/utils/Utils.js
@@ -33,6 +33,7 @@ export const mergeInputFieldProps = (defaultInputFieldsProps, props) => {
   Object.entries(overrides).forEach(([key]) => {
     Object.assign(inputFields[key], overrides[key]);
   });
+
   return inputFields;
 };
 
@@ -235,7 +236,7 @@ export const defaultSubmitFormFieldValidations = {
     message: '',
   },
   mobile: {
-    valid: false,
+    valid: true,
     value: undefined,
     message: '',
   },
@@ -323,7 +324,7 @@ export const defaultUpdateFormFieldValidations = {
     message: '',
   },
   email: {
-    valid: true,
+    valid: false,
     value: undefined,
     message: '',
   },
@@ -368,7 +369,7 @@ export const defaultUpdateFormFieldValidations = {
     message: '',
   },
   mobile: {
-    valid: false,
+    valid: true,
     value: undefined,
     message: '',
   },
@@ -378,9 +379,3 @@ export const defaultUpdateFormFieldValidations = {
 export const getRoute = (route) => {
   return `${process.env.REACT_APP_ENDPOINT_URL}${route}`;
 };
-
-
-
-
-
-

--- a/src/pages/GiftAid/utils/Utils.js
+++ b/src/pages/GiftAid/utils/Utils.js
@@ -11,11 +11,6 @@ const ENDPOINT_URL = process.env.REACT_APP_ENDPOINT_URL;
  * @param state Object
  */
 export const scrollToError = (state = {}) => {
-  // Scroll to transactionId field / url parameter error message
-  // if present
-  // if (state.urlTransactionId.valid === false) {
-  //   document.querySelector('#field-error--urlTransID').scrollIntoView({ behavior: 'smooth' });
-  // }
   // Scroll to the first erroring field and focus on its input field
   const errorWrapper = document.querySelectorAll('.form__field--erroring')[0];
   if (errorWrapper) {
@@ -89,13 +84,9 @@ export const getFormValues = (validation, urlId = null, update = false) => {
     return fieldValues[key] = value;
   });
 
-  // Create a Donation id field for Update Form
-  // NOW THERE'S NO TRANSACTION ID
-  // if ((typeof validation.transactionId !== 'undefined' && validation.transactionId) || urlId !== null) {
-
-    fieldValues.donationID = urlId;
-    
-  // }
+    // TO-DO: THERE'S NO TRANSACTION ID AT ALL NOW, WHAT SHOULD THIS BE? DO WE NEED IT?
+    // fieldValues.donationID = urlId;
+    fieldValues.donationID = null;
 
   // Create donation type field for Update Form
   fieldValues.donationType = typeof validation.donationType !== 'undefined'
@@ -144,12 +135,6 @@ export const hiddenFields = ['field-input--address1', 'field-input--town', 'fiel
 */
 export const justInTimeLinkText = 'Why do we collect this info?';
 
-/*
-* REGEX for transactionId
-*
-*/
-// const transactionIdPattern = '^\\s*[a-zA-Z0-9-_]{5,}\\s*$';
-
 /**
  * Function to validate form
  * @param validation Object
@@ -172,10 +157,6 @@ export const validateForm = (validation, formValues = {}, formValidity = {}) => 
     formValidity: true,
     showErrorMessages: false,
     validating: false,
-    // urlTransactionId: {
-    //   ...formValidity.urlTransactionId,
-    //   valid: true,
-    // }
   };
   // Validation fails for fields or transactionId
   if (fieldValidity !== true ) {
@@ -187,15 +168,6 @@ export const validateForm = (validation, formValues = {}, formValidity = {}) => 
       showErrorMessages: true,
       validating: true,
     };
-
-    // if (transIdValidity !== null && !transIdValidity && donationId !== undefined && donationId !== null) {
-
-    //   // set transaction id failed state
-    //   validationState.urlTransactionId = {
-    //     ...formValidity.urlTransactionId,
-    //     valid: false,
-    //   }
-    // }
   }
   const email = formValues.email && formValues.email !== "" ? formValues.email : 'N';
   TagManager.dataLayer({
@@ -211,14 +183,6 @@ export const validateForm = (validation, formValues = {}, formValidity = {}) => 
     validationState,
   };
 };
-
-/**
- * Validates transactionId using REGEX pattern
- * @param donationID
- * @returns Boolean
- */
-// const validateTransactionId = (donationID) => new RegExp(transactionIdPattern).test(donationID);
-
 
 /**
  * Checks if any field is invalid.
@@ -255,10 +219,6 @@ export const initialFormValidity = {
   showErrorMessages: false,
   formDataError: null,
   formDataSuccess: null,
-  // urlTransactionId: {
-  //   valid: true,
-  //   errorMessage: 'This transaction ID doesn\'t seem to be valid, please check your donation confirmation email or letter'
-  // }
 };
 
 /**
@@ -416,11 +376,6 @@ export const defaultUpdateFormFieldValidations = {
     value: undefined,
     message: '',
   },
-  // transactionId: {
-  //   valid: false,
-  //   value: undefined,
-  //   message: '',
-  // },
 };
 
 

--- a/src/pages/GiftAid/utils/Utils.js
+++ b/src/pages/GiftAid/utils/Utils.js
@@ -58,7 +58,7 @@ export const getPathParams = (update = false) => {
  * @param urlId String - url Transaction Id
  * @param update Boolean - Form type
  */
-export const getFormValues = (validation, urlId = null, update = false) => {
+export const getFormValues = (validation, update = false) => {
   // create field values
   const fieldValues = {};
 
@@ -144,11 +144,6 @@ export const justInTimeLinkText = 'Why do we collect this info?';
  */
 export const validateForm = (validation, formValues = {}, formValidity = {}) => {
 
-  // const donationId = formValues.donationID !== undefined ? formValues.donationID : null;
-
-  // validate donation id if present
-  // const transIdValidity = donationId !== null ? validateTransactionId(donationId) : null;
-
   // validate form fields
   const fieldValidity = getValidation(validation);
 
@@ -158,7 +153,7 @@ export const validateForm = (validation, formValues = {}, formValidity = {}) => 
     showErrorMessages: false,
     validating: false,
   };
-  // Validation fails for fields or transactionId
+  // Validation fails for fields
   if (fieldValidity !== true ) {
 
     // set failed fields state

--- a/src/pages/GiftAid/utils/Utils.js
+++ b/src/pages/GiftAid/utils/Utils.js
@@ -232,7 +232,7 @@ export const defaultSubmitFormFieldValidations = {
     message: '',
   },
   mobile: {
-    valid: true,
+    valid: false,
     value: undefined,
     message: '',
   },

--- a/src/pages/GiftAid/utils/Utils.js
+++ b/src/pages/GiftAid/utils/Utils.js
@@ -85,7 +85,6 @@ export const getFormValues = (validation, update = false) => {
   });
 
   // Create donation type field for Update Form
-  // TO-DO: SCOPE THIS PROPERLY
   fieldValues.donationType = typeof validation.donationType !== 'undefined'
   && validation.donationType
     ? validation.donationType.value : DONATION_TYPES.ONLINE;

--- a/src/pages/GiftAid/utils/Utils.js
+++ b/src/pages/GiftAid/utils/Utils.js
@@ -84,10 +84,6 @@ export const getFormValues = (validation, update = false) => {
     return fieldValues[key] = value;
   });
 
-    // TO-DO: THERE'S NO TRANSACTION ID AT ALL NOW, WHAT SHOULD THIS BE? DO WE NEED IT?
-    // fieldValues.donationID = urlId;
-    fieldValues.donationID = null;
-
   // Create donation type field for Update Form
   // TO-DO: SCOPE THIS PROPERLY
   fieldValues.donationType = typeof validation.donationType !== 'undefined'

--- a/src/pages/GiftAid/utils/Utils.js
+++ b/src/pages/GiftAid/utils/Utils.js
@@ -87,7 +87,7 @@ export const getFormValues = (validation, update = false) => {
 
   // Create donation type field for Update Form
   fieldValues.donationType = typeof validation.donationType !== 'undefined'
-  && validation.donationType
+    && validation.donationType
     ? validation.donationType.value : DONATION_TYPES.ONLINE;
 
   // Create name based on Form type
@@ -150,8 +150,9 @@ export const validateForm = (validation, formValues = {}, formValidity = {}) => 
     showErrorMessages: false,
     validating: false,
   };
+
   // Validation fails for fields
-  if (fieldValidity !== true ) {
+  if (fieldValidity !== true) {
 
     // set failed fields state
     validationState = {
@@ -162,6 +163,7 @@ export const validateForm = (validation, formValues = {}, formValidity = {}) => 
     };
   }
   const email = formValues.email && formValues.email !== "" ? formValues.email : 'N';
+
   TagManager.dataLayer({
     dataLayer: {
       user: {
@@ -186,19 +188,13 @@ const getValidation = (validation) => {
   let validity = true;
   let thisField;
 
-  Object.keys(validation).map((key) => {
-
+  for (const [key] of Object.entries(validation)) {
     thisField = validation[key];
 
-    /**
-     * As we're not passing any 'required' flags to this function, a quick fix to wave our
-     * optional email field through, but only if it's valid or empty
-     */
-    if (thisField.valid !== true && ( key !== 'email' || thisField.showErrorMessage === true )) {
+    if (thisField.valid !== true || thisField.showErrorMessage === true) {
       validity = false;
     }
-    return true;
-  });
+  };
 
   return validity;
 };

--- a/src/pages/GiftAid/utils/Utils.js
+++ b/src/pages/GiftAid/utils/Utils.js
@@ -367,6 +367,11 @@ export const defaultUpdateFormFieldValidations = {
     value: undefined,
     message: '',
   },
+  mobile: {
+    valid: false,
+    value: undefined,
+    message: '',
+  },
 };
 
 

--- a/src/pages/GiftAid/utils/Utils.js
+++ b/src/pages/GiftAid/utils/Utils.js
@@ -13,9 +13,9 @@ const ENDPOINT_URL = process.env.REACT_APP_ENDPOINT_URL;
 export const scrollToError = (state = {}) => {
   // Scroll to transactionId field / url parameter error message
   // if present
-  if (state.urlTransactionId.valid === false) {
-    document.querySelector('#field-error--urlTransID').scrollIntoView({ behavior: 'smooth' });
-  }
+  // if (state.urlTransactionId.valid === false) {
+  //   document.querySelector('#field-error--urlTransID').scrollIntoView({ behavior: 'smooth' });
+  // }
   // Scroll to the first erroring field and focus on its input field
   const errorWrapper = document.querySelectorAll('.form__field--erroring')[0];
   if (errorWrapper) {
@@ -90,12 +90,12 @@ export const getFormValues = (validation, urlId = null, update = false) => {
   });
 
   // Create a Donation id field for Update Form
-  if ((typeof validation.transactionId !== 'undefined' && validation.transactionId) || urlId !== null) {
+  // NOW THERE'S NO TRANSACTION ID
+  // if ((typeof validation.transactionId !== 'undefined' && validation.transactionId) || urlId !== null) {
 
-    fieldValues.donationID = typeof validation.transactionId !== 'undefined'
-    && validation.transactionId
-      ? validation.transactionId.value : urlId;
-  }
+    fieldValues.donationID = urlId;
+    
+  // }
 
   // Create donation type field for Update Form
   fieldValues.donationType = typeof validation.donationType !== 'undefined'
@@ -148,7 +148,7 @@ export const justInTimeLinkText = 'Why do we collect this info?';
 * REGEX for transactionId
 *
 */
-const transactionIdPattern = '^\\s*[a-zA-Z0-9-_]{5,}\\s*$';
+// const transactionIdPattern = '^\\s*[a-zA-Z0-9-_]{5,}\\s*$';
 
 /**
  * Function to validate form
@@ -159,10 +159,10 @@ const transactionIdPattern = '^\\s*[a-zA-Z0-9-_]{5,}\\s*$';
  */
 export const validateForm = (validation, formValues = {}, formValidity = {}) => {
 
-  const donationId = formValues.donationID !== undefined ? formValues.donationID : null;
+  // const donationId = formValues.donationID !== undefined ? formValues.donationID : null;
 
   // validate donation id if present
-  const transIdValidity = donationId !== null ? validateTransactionId(donationId) : null;
+  // const transIdValidity = donationId !== null ? validateTransactionId(donationId) : null;
 
   // validate form fields
   const fieldValidity = getValidation(validation);
@@ -172,13 +172,13 @@ export const validateForm = (validation, formValues = {}, formValidity = {}) => 
     formValidity: true,
     showErrorMessages: false,
     validating: false,
-    urlTransactionId: {
-      ...formValidity.urlTransactionId,
-      valid: true,
-    }
+    // urlTransactionId: {
+    //   ...formValidity.urlTransactionId,
+    //   valid: true,
+    // }
   };
   // Validation fails for fields or transactionId
-  if (fieldValidity !== true || (transIdValidity !== true && transIdValidity !== null) ) {
+  if (fieldValidity !== true ) {
 
     // set failed fields state
     validationState = {
@@ -187,14 +187,15 @@ export const validateForm = (validation, formValues = {}, formValidity = {}) => 
       showErrorMessages: true,
       validating: true,
     };
-    if (transIdValidity !== null && !transIdValidity && donationId !== undefined && donationId !== null) {
 
-      // set transaction id failed state
-      validationState.urlTransactionId = {
-        ...formValidity.urlTransactionId,
-        valid: false,
-      }
-    }
+    // if (transIdValidity !== null && !transIdValidity && donationId !== undefined && donationId !== null) {
+
+    //   // set transaction id failed state
+    //   validationState.urlTransactionId = {
+    //     ...formValidity.urlTransactionId,
+    //     valid: false,
+    //   }
+    // }
   }
   const email = formValues.email && formValues.email !== "" ? formValues.email : 'N';
   TagManager.dataLayer({
@@ -206,7 +207,7 @@ export const validateForm = (validation, formValues = {}, formValidity = {}) => 
     },
   });
   return {
-    validity: fieldValidity && (transIdValidity === null || transIdValidity),
+    validity: fieldValidity,
     validationState,
   };
 };
@@ -216,7 +217,7 @@ export const validateForm = (validation, formValues = {}, formValidity = {}) => 
  * @param donationID
  * @returns Boolean
  */
-const validateTransactionId = (donationID) => new RegExp(transactionIdPattern).test(donationID);
+// const validateTransactionId = (donationID) => new RegExp(transactionIdPattern).test(donationID);
 
 
 /**
@@ -254,10 +255,10 @@ export const initialFormValidity = {
   showErrorMessages: false,
   formDataError: null,
   formDataSuccess: null,
-  urlTransactionId: {
-    valid: true,
-    errorMessage: 'This transaction ID doesn\'t seem to be valid, please check your donation confirmation email or letter'
-  }
+  // urlTransactionId: {
+  //   valid: true,
+  //   errorMessage: 'This transaction ID doesn\'t seem to be valid, please check your donation confirmation email or letter'
+  // }
 };
 
 /**
@@ -415,11 +416,11 @@ export const defaultUpdateFormFieldValidations = {
     value: undefined,
     message: '',
   },
-  transactionId: {
-    valid: false,
-    value: undefined,
-    message: '',
-  },
+  // transactionId: {
+  //   valid: false,
+  //   value: undefined,
+  //   message: '',
+  // },
 };
 
 

--- a/src/styles/UpdateForm.scss
+++ b/src/styles/UpdateForm.scss
@@ -1,5 +1,6 @@
 $colour-dove-grey: #666666;
 $colour-scorpion-grey: #595959;
+$color-cr-red: #e52630;
 
 .update-giftaid__form {
   @include container;
@@ -67,6 +68,12 @@ $colour-scorpion-grey: #595959;
 
     .toggle-link {
       font-family:$font-bold;
+    }
+  }
+
+  #field-wrapper--mobile {
+    .form__field-additional-text {
+      color: $color-cr-red;
     }
   }
 }
@@ -221,5 +228,4 @@ textarea  {
       height:19px;
     }
   }
-
 }

--- a/src/styles/UpdateForm.scss
+++ b/src/styles/UpdateForm.scss
@@ -74,6 +74,7 @@ $color-cr-red: #e52630;
   #field-wrapper--mobile {
     .form__field-additional-text {
       color: $color-cr-red;
+      font-size: 14px;
     }
   }
 }

--- a/src/styles/UpdateForm.scss
+++ b/src/styles/UpdateForm.scss
@@ -127,10 +127,6 @@ button[type="submit"].btn.btn--red {
   margin: 40px 0;
 }
 
-.transaction-id {
-  color: $colour-scorpion-grey;
-}
-
 .form--update__title {
   margin: 60px 0 25px;
 }


### PR DESCRIPTION
Updates purely on the` /update` form; as per https://comicrelief.atlassian.net/browse/ENG-3255

- Remove transaction ID field, validation and any other config that relates to it

- Update and bring in improved PCLU that clarifies the UK-centricity of the postcode validation
 
- make Email Address mandatory
 
- Add a new optional Mobile Number field, but with copy to stress that if the donor made their donation via SMS we need it - NB they cannot donate via a non-UK mobile number