### PR TITLE
build: Don't treat warnings as errors in CI

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -119,6 +119,13 @@ function build(previousFileSizes) {
         }
         return reject(new Error(messages.errors.join('\n\n')));
       }
+      /*
+        The below commented-out section treats warnings as errors and fails the
+        build if the `CI` env var is set. Not clear what the original purpose of
+        this was, and we've been building in CI without the `CI` env var since
+        the beginning of time (approximately). New Concourse Tools does set `CI`
+        which is causing SPA deployments to fail.
+
       if (
         process.env.CI &&
         (typeof process.env.CI !== 'string' ||
@@ -133,6 +140,7 @@ function build(previousFileSizes) {
         );
         return reject(new Error(messages.warnings.join('\n\n')));
       }
+      */
       return resolve({
         stats,
         previousFileSizes,


### PR DESCRIPTION
[Same problem here](https://ci.services.comicrelief.com/teams/engineering/pipelines/service-giftaid/jobs/spa-deploy-staging/builds/1#L685d9473:48) as we saw in `react-donation`: with the new Concourse Tools, the warnings that were previously ignored are being treated as errors, causing the build to fail.

```
Treating warnings as errors because process.env.CI = true.
Most CI servers set it automatically.

Failed to compile.

./src/components/FormHeader/FormHeader.js
src/components/FormHeader/FormHeader.js
  Line 18:6:  React Hook useEffect has a missing dependency: 'props.page'. Either include it or remove the dependency array. If 'setPage' needs the current value of 'props.page', you can also switch to useReducer instead of useState and read 'props.page' in the reducer  react-hooks/exhaustive-deps

...

asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets: 
  static/js/vendors.047a79c4.chunk.js (1.24 MiB)

entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
Entrypoints:
  main (1.38 MiB)
      static/js/runtime~main.18f2596e.js
      static/js/vendors.047a79c4.chunk.js
      static/js/main.6d6b121f.chunk.js
```

See also https://github.com/comicrelief/react-donation/pull/1334

Relates to [ENG-4087]

[ENG-4087]: https://comicrelief.atlassian.net/browse/ENG-4087