### PR TITLE
config: update PW version to 1.50.0 and browserstack config

### DIFF
--- a/playwright-staging/browserstack.js
+++ b/playwright-staging/browserstack.js
@@ -1,39 +1,47 @@
 require('dotenv').config();
 
 const base = require('@playwright/test');
-const cp = require('child_process');
-const clientPlaywrightVersion = cp
-  .execSync('npx playwright --version')
-  .toString()
-  .trim()
-  .split(' ')[1];
+const clientPlaywrightVersion = require('@playwright/test/package.json').version; // "1.50.0"
 
 // BrowserStack Specific Capabilities.
 const caps = {
-  project: 'Giftaid',
-  // build: 'Your specified build name goes here',
+  project: 'Donation',
   name: 'e2e tests',
   browser: 'chrome',
-  resolution: '1024x768',
-  os: 'osx',
-  os_version: 'catalina',
+  browser_version: 'latest',
+  resolution: '1920x1080',
+  os: 'Windows',
+  os_version: '11',
   'browserstack.username': process.env.BROWSERSTACK_USERNAME,
   'browserstack.accessKey': process.env.BROWSERSTACK_ACCESS_KEY,
-  'client.playwrightVersion': clientPlaywrightVersion,
+  'client.playwrightVersion': '1.50.0',
+  'browserstack.playwrightVersion': '1.50.0',
+  
+  // logs
+  'browserstack.networkLogs': true,
+  'browserstack.console': 'info',
+  'browserstack.debug': true,
+  'browserstack.idleTimeout': 300,
 };
 
 // Patching the capabilities dynamically according to the project name.
 const patchCaps = (name, title) => {
-  let combination = name.split(/@browserstack/)[0];
-  let [browerCaps, osCaps] = combination.split(/:/);
-  let [browser, browser_version] = browerCaps.split(/@/);
-  let osCapsSplit = osCaps.split(/ /);
-  let os = osCapsSplit.shift();
-  let os_version = osCapsSplit.join(' ');
-  caps.browser = browser ? browser : 'chrome';
-  caps.browser_version = browser_version ? browser_version : 'latest';
-  caps.os = os ? os : 'osx';
-  caps.os_version = os_version ? os_version : 'catalina';
+  const combination = name.split(/@browserstack/)[0];
+  const [browserCaps, rawOsCaps] = combination.split(':');
+  let [browser, browser_version] = (browserCaps || '').split('@');
+  
+  browser = (browser || 'chrome').toLowerCase();
+  if (browser === 'chromium') browser = 'chrome';
+  
+  const osCaps = (rawOsCaps || '').trim();
+  const osTokens = osCaps ? osCaps.split(/\s+/) : [];
+  const os = osTokens.shift() || 'Windows';
+  const os_version = osTokens.join(' ') || '11';
+  
+  caps.browser = browser;
+  caps.browser_version = browser_version || 'latest';
+  caps.os = os;
+  caps.os_version = os_version;
   caps.name = title;
 };
 

--- a/playwright-staging/browserstack.js
+++ b/playwright-staging/browserstack.js
@@ -5,7 +5,7 @@ const clientPlaywrightVersion = require('@playwright/test/package.json').version
 
 // BrowserStack Specific Capabilities.
 const caps = {
-  project: 'Donation',
+  project: 'giftaid-react',
   name: 'e2e tests',
   browser: 'chrome',
   browser_version: 'latest',
@@ -14,8 +14,8 @@ const caps = {
   os_version: '11',
   'browserstack.username': process.env.BROWSERSTACK_USERNAME,
   'browserstack.accessKey': process.env.BROWSERSTACK_ACCESS_KEY,
-  'client.playwrightVersion': '1.50.0',
-  'browserstack.playwrightVersion': '1.50.0',
+  'client.playwrightVersion': clientPlaywrightVersion,
+  'browserstack.playwrightVersion': clientPlaywrightVersion,
   
   // logs
   'browserstack.networkLogs': true,

--- a/playwright-staging/package.json
+++ b/playwright-staging/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "@comicrelief/data-models": "^1.29.6",
     "@comicrelief/test-utils": "^1.5.15",
-    "@playwright/test": "1.25.1",
+    "@playwright/test": "1.50.0",
     "axios": "^0.21.1",
     "chance": "^1.1.7",
     "dotenv": "^8.0.0",

--- a/playwright-staging/playwright.config.js
+++ b/playwright-staging/playwright.config.js
@@ -22,6 +22,9 @@ const config = {
     actionTimeout: 0,
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'retain-on-failure',
+    navigationTimeout: 45000,
+    scriptTimeout: 60000, // this is needed for long running scripts
+    serviceWorkers: 'block', // optional but reduces flakiness
   },
   grep: [new RegExp('@regression'), new RegExp('@sanity'), new RegExp('@nightly-sanity')],
 
@@ -30,7 +33,7 @@ const config = {
     // -- BrowserStack Projects --
     // name should be of the format browser@browser_version:os os_version@browserstack
     {
-      name: 'chrome@latest:Windows 10@browserstack',
+      name: 'chrome@latest:Windows 11@browserstack',
       use: {
         browserName: 'chromium',
         ...devices['Desktop Chrome'],

--- a/playwright-staging/yarn.lock
+++ b/playwright-staging/yarn.lock
@@ -64,18 +64,12 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@playwright/test@1.25.1":
-  version "1.25.1"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.25.1.tgz#9847234b6f2b0cca71962b338da7db366a1e9720"
-  integrity sha512-IJ4X0yOakXtwkhbnNzKkaIgXe6df7u3H3FnuhI9Jqh+CdO0e/lYQlDLYiyI9cnXK8E7UAppAWP+VqAv6VX7HQg==
+"@playwright/test@1.50.0":
+  version "1.50.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.50.0.tgz#25c63a09f833f89da4d54ad67db7900359e2d11d"
+  integrity sha512-ZGNXbt+d65EGjBORQHuYKj+XhCewlwpnSd/EDuLPZGSiEWmgOJB5RmMCCYGy5aMfTs9wx61RivfDKi8H/hcMvw==
   dependencies:
-    "@types/node" "*"
-    playwright-core "1.25.1"
-
-"@types/node@*":
-  version "18.14.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.14.2.tgz#c076ed1d7b6095078ad3cf21dfeea951842778b1"
-  integrity sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA==
+    playwright "1.50.0"
 
 acorn@^8.5.0:
   version "8.8.2"
@@ -190,6 +184,11 @@ follow-redirects@^1.14.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 gulp-uglify-es@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/gulp-uglify-es/-/gulp-uglify-es-3.0.0.tgz#00466e0e3b0486057c552b8b0d3e326791f2f832"
@@ -245,10 +244,19 @@ o-stream@^0.3.0:
   resolved "https://registry.yarnpkg.com/o-stream/-/o-stream-0.3.0.tgz#204d27bc3fb395164507d79b381e91752e8daedc"
   integrity sha512-gbzl6qCJZ609x/M2t25HqCYQagFzWYCtQ84jcuObGr+V8D1Am4EVubkF4J+XFs6ukfiv96vNeiBb8FrbbMZYiQ==
 
-playwright-core@1.25.1:
-  version "1.25.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.25.1.tgz#abe56aec8bef645fba988320d9f9328fafab0446"
-  integrity sha512-lSvPCmA2n7LawD2Hw7gSCLScZ+vYRkhU8xH0AapMyzwN+ojoDqhkH/KIEUxwNu2PjPoE/fcE0wLAksdOhJ2O5g==
+playwright-core@1.50.0:
+  version "1.50.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.50.0.tgz#28dd6a1488211c193933695ed337a5b44d46867c"
+  integrity sha512-CXkSSlr4JaZs2tZHI40DsZUN/NIwgaUPsyLuOAaIZp2CyF2sN5MM5NJsyB188lFSSozFxQ5fPT4qM+f0tH/6wQ==
+
+playwright@1.50.0:
+  version "1.50.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.50.0.tgz#ccaf334f948d78139922844de55a18f8ae785410"
+  integrity sha512-+GinGfGTrd2IfX1TA4N2gNmeIksSb+IAe589ZH+FlmpV3MYTx6+buChGIuDLQwrGNCw2lWibqV50fU510N7S+w==
+  dependencies:
+    playwright-core "1.50.0"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 plugin-error@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Nightly tests started failing recently as BrowserStack is no longer supporting Playwright 1.25.0 running on Windows 10 OS. Have updated the Docker image on the concourse-tools repo to use playwright 1.50.0 and it's more stable than the latest one. BS and PW docker image version should be same. Playwright tests on Browserstack are now running on windows 11, chrome latest version.

https://github.com/comicrelief/concourse-tools/pull/75