### PR TITLE
fix: Allow 071 and 073 mobile numbers

### DIFF
--- a/playwright-local/tests/update/formValidation.spec.js
+++ b/playwright-local/tests/update/formValidation.spec.js
@@ -168,7 +168,7 @@ test.describe('Giftaid update form validation', () => {
   test('Validate mobile number field', async ({ page }) => {
     const commands = new Commands(page);
     // List of allowed prefixes for UK mobile numbers
-    const prefixes = ['074', '075', '077', '078', '079'];
+    const prefixes = ['071', '073', '074', '075', '077', '078', '079'];
     // Randomly select one prefix from the list
     const prefix = chance.pickone(prefixes);
     // Generate the remaining 8 digits randomly
@@ -177,16 +177,22 @@ test.describe('Giftaid update form validation', () => {
     
     // Test cases for various mobile number validations
     const mobileTestCases = [
-      { input: '0712345678', error: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.' },
-      { input: '0712345678900', error: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.' },
-      { input: '0712 345 6789', error: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.' },
+      { input: '0722345678', error: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.' },
+      { input: '0722345678900', error: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.' },
+      { input: '0722 345 6789', error: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.' },
       { input: '0780ab5694245', error: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.' },
+      { input: '07123456789', valid: true },
+      { input: '07340707252', valid: true },
     ];
     
     for (let testCase of mobileTestCases) {
       await page.locator('#field-input--mobile').fill(''); // Clear the field before each test
       await page.locator('#field-input--mobile').type(testCase.input, { delay: 100 });
-      await expect(page.locator('div#field-error--mobile > span')).toHaveText(testCase.error);
+      if (testCase.valid) {
+        await expect(page.locator('div#field-error--mobile > span')).not.toBeVisible();
+      } else {
+        await expect(page.locator('div#field-error--mobile > span')).toHaveText(testCase.error);
+      }
     }
     
     // Validate correct mobile number

--- a/playwright-staging/tests/update/formValidation.spec.js
+++ b/playwright-staging/tests/update/formValidation.spec.js
@@ -96,7 +96,7 @@ test.describe('Giftaid Update form validation @sanity @nightly-sanity', () => {
   test('Validate mobile number field on giftaid update form', async ({ page }) => {
     const commands = new Commands(page);
     // List of allowed prefixes for UK mobile numbers
-    const prefixes = ['074', '075', '077', '078', '079'];
+    const prefixes = ['071', '073', '074', '075', '077', '078', '079'];
     // Randomly select one prefix from the list
     const prefix = chance.pickone(prefixes);
     // Generate the remaining 8 digits randomly
@@ -105,16 +105,22 @@ test.describe('Giftaid Update form validation @sanity @nightly-sanity', () => {
     
     // Test cases for various mobile number validations
     const mobileTestCases = [
-      { input: '0712345678', error: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.' },
-      { input: '0712345678900', error: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.' },
-      { input: '0712 345 6789', error: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.' },
+      { input: '0722345678', error: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.' },
+      { input: '0722345678900', error: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.' },
+      { input: '0722 345 6789', error: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.' },
       { input: '0780ab5694245', error: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.' },
+      { input: '07123456789', valid: true },
+      { input: '07340707252', valid: true },
     ];
     
     for (let testCase of mobileTestCases) {
       await page.locator('#field-input--mobile').fill(''); // Clear the field before each test
       await page.locator('#field-input--mobile').type(testCase.input, { delay: 100 });
-      await expect(page.locator('div#field-error--mobile > span')).toHaveText(testCase.error);
+      if (testCase.valid) {
+        await expect(page.locator('div#field-error--mobile > span')).not.toBeVisible();
+      } else {
+        await expect(page.locator('div#field-error--mobile > span')).toHaveText(testCase.error);
+      }  
     }
     
     // Validate correct mobile number

--- a/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
+++ b/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
@@ -66,7 +66,7 @@ export const updateFormFields = {
     placeholder: 'In the format 07123456789',
     label: 'Mobile number',
     required: false,
-    pattern: '^(?:(?:00)?44|0)7(?:[13457-9]\\d{2}|624)\\d{6}$', // As per Update.action.js in serverless-giftaid
+    pattern: '^(?:(?:00)?44|0)7(?:[13-57-9]\\d{2}|624)\\d{6}$', // As per Update.action.js in serverless-giftaid
     helpText: 'Enter the one associated with your donation',
     emptyFieldErrorText: 'Please fill in your mobile number',
     invalidErrorText: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.',

--- a/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
+++ b/src/pages/GiftAid/UpdateForm/UpdateFormFields.js
@@ -66,7 +66,7 @@ export const updateFormFields = {
     placeholder: 'In the format 07123456789',
     label: 'Mobile number',
     required: false,
-    pattern: '^(?:(?:00)?44|0)7(?:[457-9]\\d{2}|624)\\d{6}$', // As per Update.action.js in serverless-giftaid
+    pattern: '^(?:(?:00)?44|0)7(?:[13457-9]\\d{2}|624)\\d{6}$', // As per Update.action.js in serverless-giftaid
     helpText: 'Enter the one associated with your donation',
     emptyFieldErrorText: 'Please fill in your mobile number',
     invalidErrorText: 'Please enter a valid mobile phone number - it must be the same number associated with your donation.',


### PR DESCRIPTION
Currently the mobile phone regex doesn't allow the valid UK phone number prefixes 071 and 073

No Jira